### PR TITLE
[APIDX-921] Set AccessTokenModel's refresh_token property nullable

### DIFF
--- a/api-specifications/marketingsolutions_2021-10.json
+++ b/api-specifications/marketingsolutions_2021-10.json
@@ -3397,7 +3397,8 @@
           },
           "refresh_token": {
             "type": "string",
-            "description": "The refresh token issued by the authorization server.\r\n///"
+            "description": "The refresh token issued by the authorization server.\r\n///",
+            "x-nullable": true
           },
           "expires_in": {
             "type": "integer",

--- a/api-specifications/marketingsolutions_preview.json
+++ b/api-specifications/marketingsolutions_preview.json
@@ -10961,7 +10961,8 @@
           },
           "refresh_token": {
             "type": "string",
-            "description": "The refresh token issued by the authorization server.\r\n///"
+            "description": "The refresh token issued by the authorization server.\r\n///",
+            "x-nullable": true
           },
           "expires_in": {
             "type": "integer",

--- a/api-specifications/retailmedia_2021-10.json
+++ b/api-specifications/retailmedia_2021-10.json
@@ -2904,7 +2904,8 @@
           },
           "refresh_token": {
             "type": "string",
-            "description": "The refresh token issued by the authorization server.\r\n///"
+            "description": "The refresh token issued by the authorization server.\r\n///",
+            "x-nullable": true
           },
           "expires_in": {
             "type": "integer",

--- a/api-specifications/retailmedia_preview.json
+++ b/api-specifications/retailmedia_preview.json
@@ -1845,7 +1845,8 @@
           },
           "refresh_token": {
             "type": "string",
-            "description": "The refresh token issued by the authorization server.\r\n///"
+            "description": "The refresh token issued by the authorization server.\r\n///",
+            "x-nullable": true
           },
           "expires_in": {
             "type": "integer",


### PR DESCRIPTION
The AccessTokenModel returned from the /oauth2/token endpoint can have a null refresh_token property. Python SDKs are not able to deserialize such responses as it expects a string for the refresh_token property.
To fix this we need to explicitly specify in the swaggers that the refresh_token property can be null.