### PR TITLE
🐛 Fix refresh token mechanism

### DIFF
--- a/generator/java/resources/templates/ApiClient.mustache
+++ b/generator/java/resources/templates/ApiClient.mustache
@@ -1526,11 +1526,7 @@ public class ApiClient {
         OAuth oauth = (OAuth) this.getAuthentication("oauth");
         String accessToken = oauth.getAccessToken();
 
-        if (accessToken != null) {
-            return;
-        }
-
-        if (this.tokenInfo != null && this.tokenInfo.isValid()) {
+        if (accessToken != null && this.tokenInfo != null && this.tokenInfo.isValid()) {
             return;
         }
     


### PR DESCRIPTION
If the accessToken isn't null, it doesn't always mean that it is valid. If the token is expired, we should refresh it.

JIRA: APIDX-1305