### PR TITLE
Fix assetfile type from file to string with binary format

### DIFF
--- a/api-specifications/retailmedia_2022-04.json
+++ b/api-specifications/retailmedia_2022-04.json
@@ -355,8 +355,9 @@
                 ],
                 "properties": {
                   "AssetFile": {
-                    "type": "file",
-                    "description": "The asset binary content"
+                    "type": "string",
+                    "description": "The asset binary content",
+                    "format": "binary"
                   }
                 }
               }

--- a/api-specifications/retailmedia_2022-07.json
+++ b/api-specifications/retailmedia_2022-07.json
@@ -355,8 +355,9 @@
                 ],
                 "properties": {
                   "AssetFile": {
-                    "type": "file",
-                    "description": "The asset binary content"
+                    "type": "string",
+                    "description": "The asset binary content",
+                    "format": "binary"
                   }
                 }
               }

--- a/api-specifications/retailmedia_2022-10.json
+++ b/api-specifications/retailmedia_2022-10.json
@@ -355,8 +355,9 @@
                 ],
                 "properties": {
                   "AssetFile": {
-                    "type": "file",
-                    "description": "The asset binary content"
+                    "type": "string",
+                    "description": "The asset binary content",
+                    "format": "binary"
                   }
                 }
               }

--- a/api-specifications/retailmedia_2023-01.json
+++ b/api-specifications/retailmedia_2023-01.json
@@ -355,8 +355,9 @@
                 ],
                 "properties": {
                   "AssetFile": {
-                    "type": "file",
-                    "description": "The asset binary content"
+                    "type": "string",
+                    "description": "The asset binary content",
+                    "format": "binary"
                   }
                 }
               }


### PR DESCRIPTION
Fixes the issue:
https://github.com/criteo/criteo-api-python-sdk/issues/14