### PR TITLE
Generate valid PHP snippet in README

### DIFF
--- a/generator/php/resources/templates/README.mustache
+++ b/generator/php/resources/templates/README.mustache
@@ -78,7 +78,7 @@ $clientSecret = 'YOUR_CLIENT_SECRET';
 $apiInstance = new {{invokerPackage}}\Api\{{classname}}(new {{invokerPackage}}\TokenAutoRefreshClient($clientId, $clientSecret));
 
 {{#allParams}}
-${{paramName}} = {{{example}}};
+${{paramName}} = "{{{example}}}";
 {{/allParams}}
 
 try {


### PR DESCRIPTION
Without this patch the generated README has a snippet of code with the line

    $report_id = ee439121-13e3-4734-9f67-c504dd921a41;

(see eg https://github.com/criteo/criteo-api-retailmedia-php-sdk/blob/9aa0c49955427a02991017c3aec3f583b87080a6/README.md )

With this commit, this line looks like

    $report_id = "ee439121-13e3-4734-9f67-c504dd921a41";

which is hence valid PHP