### PR TITLE
Fix http basic auth not setup issue

### DIFF
--- a/generator/java/resources/templates/api_doc.mustache
+++ b/generator/java/resources/templates/api_doc.mustache
@@ -26,6 +26,7 @@ All URIs are relative to *{{basePath}}*
 package {{invokerPackage}};
 
 import {{{invokerPackage}}}.ApiClient;
+import {{{invokerPackage}}}.ApiClientBuilder;
 import {{{invokerPackage}}}.ApiException;
 import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
 import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
@@ -34,33 +35,33 @@ import {{{package}}}.{{{classname}}};
 
 public class Example {
     public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
-        defaultClient.setBasePath("{{{basePath}}}");
         {{#hasAuthMethods}}
-        {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        {{#authMethods}}
+
+        {{#isOAuth}}
+        // Configure OAuth2, two options:
+        // 1. Use ApiClientBuilder to create the ApiClient with the credentials you want, refresh token mechanism IS handled for you 💚
+        String clientId = "YOUR CLIENT ID";
+        String clientSecret = "YOUR CLIENT SECRET";
+        ApiClient defaultClient = ApiClientBuilder.ForClientCredentials(clientId, clientSecret);
+        
+        // 2. Set your access token manually, refresh token mechanism IS NOT handled by the client
+        // ApiClient defaultClient = Configuration.getDefaultApiClient();
+        // OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
+        // {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}{{#isBasic}}{{#isBasicBasic}}
         // Configure HTTP basic authorization: {{{name}}}
         HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
         {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
         // Configure HTTP bearer authorization: {{{name}}}
         HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}
+        {{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");
         // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
-        // Configure OAuth2, two options:
-        // 1. Set your access token manually, refresh token mechanism IS NOT handled by the client
-        OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
-
-        // 2. Set your credentials within the ApiClient, refresh token mechanism IS handled for you 💚
-        defaultClient.setUsername("YOUR CLIENT ID");
-        defaultClient.setPassword("YOUR CLIENT SECRET");
-        {{/authMethods}}
-        {{/hasAuthMethods}}
-
+        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{/authMethods}}{{/hasAuthMethods}}
         {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
         {{#allParams}}
         {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}

--- a/sandbox/java/src/main/java/com/criteo/app/App.java
+++ b/sandbox/java/src/main/java/com/criteo/app/App.java
@@ -12,8 +12,8 @@ public class App {
     public static void main(String[] args) {
         
         // Configure OAuth2, two options:
-        // 1. Set your credentials within the ApiClient, refresh token mechanism IS handled for you 💚
-        String clientId = "YOUR_CIENT_ID";
+        // 1. Use ApiClientBuilder to create the ApiClient with the credentials you want, refresh token mechanism IS handled for you 💚
+        String clientId = "YOUR_CLIENT_ID";
         String clientSecret = "YOUR_CLIENT_SECRET";
         ApiClient defaultClient = ApiClientBuilder.ForClientCredentials(clientId, clientSecret);
 

--- a/sandbox/java/src/main/java/com/criteo/app/App.java
+++ b/sandbox/java/src/main/java/com/criteo/app/App.java
@@ -1,6 +1,7 @@
 package com.criteo.app;
 
 import com.criteo.api.marketingsolutions.v2022_07.ApiClient;
+import com.criteo.api.marketingsolutions.v2022_07.ApiClientBuilder;
 import com.criteo.api.marketingsolutions.v2022_07.ApiException;
 import com.criteo.api.marketingsolutions.v2022_07.Configuration;
 import com.criteo.api.marketingsolutions.v2022_07.auth.*;
@@ -9,16 +10,17 @@ import com.criteo.api.marketingsolutions.v2022_07.api.AdvertiserApi;
 
 public class App {
     public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
         
         // Configure OAuth2, two options:
-        // 1. Set your access token manually, refresh token mechanism IS NOT handled by the client
-        OAuth oauth = (OAuth) defaultClient.getAuthentication("oauth");
-        oauth.setAccessToken("YOUR_TOKEN");
+        // 1. Set your credentials within the ApiClient, refresh token mechanism IS handled for you 💚
+        String clientId = "YOUR_CIENT_ID";
+        String clientSecret = "YOUR_CLIENT_SECRET";
+        ApiClient defaultClient = ApiClientBuilder.ForClientCredentials(clientId, clientSecret);
 
-        // 2. Set your credentials within the ApiClient, refresh token mechanism IS handled for you 💚
-        // defaultClient.setUsername("YOUR_CIENT_ID");
-        // defaultClient.setPassword("YOUR_CLIENT_SECRET");
+        // 2. Set your access token manually, refresh token mechanism IS NOT handled by the client
+        // ApiClient defaultClient = Configuration.getDefaultApiClient();
+        // OAuth oauth = (OAuth) defaultClient.getAuthentication("oauth");
+        // oauth.setAccessToken("YOUR_TOKEN");
 
         AdvertiserApi apiInstance = new AdvertiserApi(defaultClient);
         try {


### PR DESCRIPTION
HttpBasicAuth is not supported unless explicitly mentioned in the API Spec.
So the client cannot `setUsername` or `setPassword` in the SDK as we have.
This has been fixed by using ApiClientBuilder directly when creating a client with id and secret.

+ The doc template has been updated to align with the update.