### PR TITLE
[PHP] upgrade to openapi-generator 6.3.0

### DIFF
--- a/generator/php/build.gradle
+++ b/generator/php/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:5.2.1"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:6.3.0"
     }
 }
 

--- a/generator/php/resources/templates/ClientCredentialsClient.mustache
+++ b/generator/php/resources/templates/ClientCredentialsClient.mustache
@@ -59,13 +59,8 @@ class ClientCredentialsClient implements \GuzzleHttp\ClientInterface
      */
     public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
-        $requiresAuthentication = $request->getHeader(AUTHORIZATION) != null;
-        if (!$requiresAuthentication) {
-            return $this->client->send($request, $options);
-        } else {
-            $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
-            return $this->client->send($requestWithUpdatedAuthorizationHeader, $options);
-        }
+        $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
+        return $this->client->send($requestWithUpdatedAuthorizationHeader, $options);
     }
 
     /**
@@ -80,13 +75,8 @@ class ClientCredentialsClient implements \GuzzleHttp\ClientInterface
      */
     public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
     {
-        $requireAuthentication = $request->getHeader(AUTHORIZATION) != null;
-        if (!$requireAuthentication) {
-            return $this->client->sendAsync($request, $options);
-        } else {
-            $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
-            return $this->client->sendAsync($requestWithUpdatedAuthorizationHeader, $options);
-        }
+        $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
+        return $this->client->sendAsync($requestWithUpdatedAuthorizationHeader, $options);
     }
 
     /**

--- a/generator/php/resources/templates/GatewayApiTest.mustache
+++ b/generator/php/resources/templates/GatewayApiTest.mustache
@@ -89,8 +89,8 @@ class GatewayApiTest extends TestCase
 
                 // Assert
                 $this->assertEquals(401, $exception->getCode());
-                $this->assertEquals('authorization', $data->getErrors()[0]->getType());
-                $this->assertEquals('authorization-token-invalid', $data->getErrors()[0]->getCode());
+                $this->assertEquals('authentication', $data->getErrors()[0]->getType());
+                $this->assertEquals('authentication-required', $data->getErrors()[0]->getCode());
             }
         );
     }


### PR DESCRIPTION
Some changes in our custom template and generated tests are needed with this upgrade. That's because the generated code is slightly different:

The behavior before the upgrade
===============================
with the previous version of openapi-generator we used, the generated code added an authorization header if that condition was met:

    $this->config->getAccessToken() !== null

but that condition was always true because the access token was by default an empty string (which is hence not null). Consequently the requests all had the header "Authorization" set to "Bearer ". That value is ofc invalid (because the token itself is an empty string) but that did not matter because in our ClientCredentialsClient::send we run this:

    $requiresAuthentication = $request->getHeader(AUTHORIZATION) != null;

which led $requiresAuthentication to be TRUE (because string "Bearer " is not null) and hence to subsequently run
ClientCredentialsClient::refreshToken which was responsible for setting a correct "Authorization" header (with a valid token)

The behavior with this upgrade
==============================
With the upgraded version of openapi-generator, that 1st condition becomes

    !empty($this->config->getAccessToken())

which is now always false (because we don't expect the user to set any access token, instead we let our ad hoc ClientCredentialsClient handle those token considerations).
Subsequently that line

    $requiresAuthentication = $request->getHeader(AUTHORIZATION) != null;

led $requiresAuthentication to be false, so we always sent queries without trying to set a header

The fix applied in the generated lib
====================================
To avoid this issue we just let the ClientCredentialsClient always add a "Authorization" header. Because:
- that was the former behavior
- it sounds a reasonable behavior for a class called "ClientCredentialsClient"

The change applied in the generated test
========================================
The test GatewayApiTest::testGetCurrentApplicationShouldFailWithoutToken also had to be changed sligthly. That's because before this commit, this test ended up sending a query with "Authorization" header set to "Bearer: ", which hence received an error response which says that the token is invalid.
With the openapi-generator bump, that test now sends a query without "Authorization" header at all (for the reasons explained previously). Consequenly we still receive a 401 as expected, but now the body of the error is a bit different.