### PR TITLE
Run tests with PHP 8

### DIFF
--- a/.github/workflows/generate_php_sources.yml
+++ b/.github/workflows/generate_php_sources.yml
@@ -32,7 +32,7 @@ jobs:
         uses: php-actions/composer@v6
         with:
           version: 2
-          php_version: 7.4
+          php_version: 8.0
           command: about
 
       - uses: webfactory/ssh-agent@v0.5.4

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -30,7 +30,7 @@ jobs:
         uses: php-actions/composer@v6
         with:
           version: 2
-          php_version: 7.4
+          php_version: 8.0
           command: about
 
       - name: Install dependencies

--- a/generator/php/build.gradle
+++ b/generator/php/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:5.2.1"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:6.3.0"
     }
 }
 

--- a/generator/php/resources/templates/ClientCredentialsClient.mustache
+++ b/generator/php/resources/templates/ClientCredentialsClient.mustache
@@ -59,13 +59,8 @@ class ClientCredentialsClient implements \GuzzleHttp\ClientInterface
      */
     public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
-        $requiresAuthentication = $request->getHeader(AUTHORIZATION) != null;
-        if (!$requiresAuthentication) {
-            return $this->client->send($request, $options);
-        } else {
-            $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
-            return $this->client->send($requestWithUpdatedAuthorizationHeader, $options);
-        }
+        $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
+        return $this->client->send($requestWithUpdatedAuthorizationHeader, $options);
     }
 
     /**
@@ -80,13 +75,8 @@ class ClientCredentialsClient implements \GuzzleHttp\ClientInterface
      */
     public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
     {
-        $requireAuthentication = $request->getHeader(AUTHORIZATION) != null;
-        if (!$requireAuthentication) {
-            return $this->client->sendAsync($request, $options);
-        } else {
-            $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
-            return $this->client->sendAsync($requestWithUpdatedAuthorizationHeader, $options);
-        }
+        $requestWithUpdatedAuthorizationHeader = $this->refreshToken($request);
+        return $this->client->sendAsync($requestWithUpdatedAuthorizationHeader, $options);
     }
 
     /**

--- a/generator/php/resources/templates/GatewayApiTest.mustache
+++ b/generator/php/resources/templates/GatewayApiTest.mustache
@@ -89,8 +89,8 @@ class GatewayApiTest extends TestCase
 
                 // Assert
                 $this->assertEquals(401, $exception->getCode());
-                $this->assertEquals('authorization', $data->getErrors()[0]->getType());
-                $this->assertEquals('authorization-token-invalid', $data->getErrors()[0]->getCode());
+                $this->assertEquals('authentication', $data->getErrors()[0]->getType());
+                $this->assertEquals('authentication-required', $data->getErrors()[0]->getCode());
             }
         );
     }

--- a/generator/php/resources/templates/GatewayApiTest.mustache
+++ b/generator/php/resources/templates/GatewayApiTest.mustache
@@ -56,20 +56,6 @@ class GatewayApiTest extends TestCase
         $this->assertEquals($this->applicationId, $response[0]->getData()->getAttributes()->getApplicationId());
     }
 
-    public function testGetCurrentApplicationShouldSucceedWithRenewedInvalidToken()
-    {
-        // Arrange
-        $api = new GatewayApi(new ClientCredentialsClient($this->clientId, $this->clientSecret));
-        $api->getConfig()->setAccessToken('invalid-access-token');
-
-        // Act
-        $response = $api->getCurrentApplicationWithHttpInfo();
-
-        // Assert
-        $this->assertEquals(200, $response[1]);
-        $this->assertEquals($this->applicationId, $response[0]->getData()->getAttributes()->getApplicationId());
-    }
-
     public function testGetCurrentApplicationShouldFailWithoutToken()
     {
         $this->assertThrows(ApiException::class, 

--- a/generator/php/resources/templates/GatewayApiTest.mustache
+++ b/generator/php/resources/templates/GatewayApiTest.mustache
@@ -56,6 +56,19 @@ class GatewayApiTest extends TestCase
         $this->assertEquals($this->applicationId, $response[0]->getData()->getAttributes()->getApplicationId());
     }
 
+    public function testGetCurrentApplicationAsyncShouldSucceedWithValidToken()
+    {
+        // Arrange
+        $api = new GatewayApi(new ClientCredentialsClient($this->clientId, $this->clientSecret));
+
+        // Act
+        $response = $api->getCurrentApplicationAsyncWithHttpInfo()->wait();
+
+        // Assert
+        $this->assertEquals(200, $response[1]);
+        $this->assertEquals($this->applicationId, $response[0]->getData()->getAttributes()->getApplicationId());
+    }
+
     public function testGetCurrentApplicationShouldFailWithoutToken()
     {
         $this->assertThrows(ApiException::class, 

--- a/generator/php/resources/templates/README.mustache
+++ b/generator/php/resources/templates/README.mustache
@@ -19,7 +19,8 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}})
 
 ## Requirements
 
-PHP 7.1 and later
+This project is tested with PHP 8.0.
+However it should work fine with PHP 7.x too.
 
 ## Installation & Usage
 


### PR DESCRIPTION
PHP 7.x is not supported anymore (end of support of PHP 7.4 was in     
November 2022). The latest version is PHP 8.2, however I guess it makes
sense to test with the oldest still maintained version, to make sure we
don't use features not supported by those.

Note that I only change:
-the version used in CI (in order to ensure our sdk is compatible with  supported version of PHP)
- the version mentioned in README (to avoid giving the feeling that our  repo is obsolete)
but that I don't change the requirement in the generated composer file on purpose, in order to not take the risk to break compatibility for clients with old PHP version.

(Note that this PR is based on top of PR #69 ; if you review this one before that other is merged, you can have a look at the last commit only)