### PR TITLE
:technologist: create config files for java generation in a gitignored folder

### DIFF
--- a/generator/java/build.gradle
+++ b/generator/java/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 apply plugin: 'org.openapi.generator'
 
 def clientOutputDir = "$projectDir/../../$rootProject.gereratedClientsDirName/java".toString()
+def buildDir = "$projectDir/build";
 def resourcesDir = "$projectDir/resources".toString()
 def criteoPackage = project.properties["package.name.base"]
 def basePackagePath = criteoPackage.replace(".", "/")
@@ -34,8 +35,8 @@ task generateClient(type: GradleBuild) {
     group 'Criteo'
     description "Generate the {language.toUpperCase()} client using openapi-generator and custom templates".toString()
 	
-    def taskList = ['cleanPreviousJavaBuild'];
-
+    def taskList = [];
+    
 	rootProject.swaggerSourceList.each {
         def jsonFile = file(it.path);
         def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text);
@@ -57,18 +58,23 @@ task generateClient(type: GradleBuild) {
         def artifactVersion = isPreviewVersion ? '0' : criteoApiVersion.replaceAll("_",".").toString()
         artifactVersion += ".${generatorVersion}.${getFormattedDate()}".toString() // example : 2021.01.0.211110 for stable , 0.0.211110 for preview
        
-        namespaceBase = "com." + namespaceBase; // 'com' is Java-specific => exmaple: com.criteo.api.marketingsolutions.v2021_10
+        namespaceBase = "com." + namespaceBase; // 'com' is Java-specific => example: com.criteo.api.marketingsolutions.v2021_10
 
         // useful when you want templates to be part of the SDK generated
         def sdkMainDir = 'src/main/java/com/criteo/api/' + criteoService + '/' + versionInNamespace
-        def file = new File("$projectDir/generatorConfiguration.yaml")
-        def configFileForCriteoServiceVersion = new File("$projectDir/${criteoService}-${versionInNamespace}.yaml")
-        def configContent = file.text.replace('sdkFolder', sdkMainDir)
-        configFileForCriteoServiceVersion.text = configContent
+
+        def createConfig  = task("createConfig_${technologyStack}_" + parsedApiName) {
+            mkdir "$buildDir"
+            def file = new File("$projectDir/generatorConfiguration.yaml")
+            def configFileForCriteoServiceVersion = new File("$buildDir/${criteoService}-${versionInNamespace}.yaml")
+            def configContent = file.text.replace('sdkFolder', sdkMainDir)
+            configFileForCriteoServiceVersion.text = configContent
+        }
+        createConfig.dependsOn(cleanPreviousJavaBuild.name)
 
         def generateTask = task("openApiGenerate_${technologyStack}_" + parsedApiName, type: GenerateTask.class) {
             generatorName = "$language".toString()
-            configFile = "$projectDir/${criteoService}-${versionInNamespace}.yaml".toString()
+            configFile = "${buildDir}/${criteoService}-${versionInNamespace}.yaml".toString()
             templateDir = "$resourcesDir/templates/".toString()
             inputSpec = specPath
             outputDir = clientOutputDirPerVersion
@@ -97,6 +103,8 @@ task generateClient(type: GradleBuild) {
                     disallowAdditionalPropertiesIfNotPresent : 'false',
             ]
         }
+        generateTask.dependsOn(createConfig.name)
+
         def copyLicense = task("copyLicense_" + technologyStack + "_" + parsedApiName, type: Copy) {
             group 'Criteo'
             description 'Copy the license into the client output folder'


### PR DESCRIPTION
The config files for java generation are now generated into a build/ subfolder that is ignored by git, preventing the temporary files to be unexpectedly pushed onto the repository