### PR TITLE
Add authorizationCode to securitySchemes

### DIFF
--- a/api-specifications/marketingsolutions_2022-04.json
+++ b/api-specifications/marketingsolutions_2022-04.json
@@ -4783,6 +4783,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/marketingsolutions_2022-07.json
+++ b/api-specifications/marketingsolutions_2022-07.json
@@ -4783,6 +4783,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/marketingsolutions_2022-10.json
+++ b/api-specifications/marketingsolutions_2022-10.json
@@ -4783,6 +4783,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/marketingsolutions_2023-01.json
+++ b/api-specifications/marketingsolutions_2023-01.json
@@ -4783,6 +4783,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/marketingsolutions_preview.json
+++ b/api-specifications/marketingsolutions_preview.json
@@ -20454,6 +20454,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/retailmedia_2022-04.json
+++ b/api-specifications/retailmedia_2022-04.json
@@ -6917,6 +6917,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/retailmedia_2022-07.json
+++ b/api-specifications/retailmedia_2022-07.json
@@ -7845,6 +7845,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/retailmedia_2022-10.json
+++ b/api-specifications/retailmedia_2022-10.json
@@ -7845,6 +7845,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/retailmedia_2023-01.json
+++ b/api-specifications/retailmedia_2023-01.json
@@ -8675,6 +8675,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }

--- a/api-specifications/retailmedia_preview.json
+++ b/api-specifications/retailmedia_preview.json
@@ -7565,6 +7565,11 @@
           "clientCredentials": {
             "tokenUrl": "https://api.criteo.com/oauth2/token",
             "scopes": { }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "https://api.criteo.com/oauth2",
+            "tokenUrl": "https://api.criteo.com/oauth2/token",
+            "scopes": { }
           }
         }
       }


### PR DESCRIPTION
Criteo API supports authorizationCode OAuth flow and the SDKs will support that in the near future.
This PR has been created to make that visible/explicit.