### PR TITLE
Add auth code refresh token mechanism for python SDK

### DIFF
--- a/generator/python/generatorConfiguration.yaml
+++ b/generator/python/generatorConfiguration.yaml
@@ -23,7 +23,15 @@ files:
     folder : test
     templateType: SupportingFiles
     destinationFilename: test_gateway_api.py
-  custom/example_application.py.mustache:
+  custom/example_application_with_client_credentials.py.mustache:
     folder : test
     templateType: SupportingFiles
-    destinationFilename: example_application.py
+    destinationFilename: example_application_with_client_credentials.py
+  custom/example_application_with_auth_code.py.mustache:
+    folder : test
+    templateType: SupportingFiles
+    destinationFilename: example_application_with_auth_code.py
+  custom/example_application_with_refresh_token.py.mustache:
+    folder : test
+    templateType: SupportingFiles
+    destinationFilename: example_application_with_refresh_token.py

--- a/generator/python/resources/templates/README.mustache
+++ b/generator/python/resources/templates/README.mustache
@@ -48,7 +48,11 @@ import {{{packageName}}}
 ```
 
 ## Example
-Please see [test/example_application.py](test/example_application.py) for an example.
+There are multiple examples for the different OAuth flows that the SDK supports.
+- See [test/example_application_with_client_credentials.py](test/example_application_with_client_credentials.py) for an example with Client Credentials.
+- See [test/example_application_with_auth_code.py](test/example_application_with_auth_code.py) for an example with Authorization Code.
+Once you follow the authorization code flow, you will have a refresh token that has to be used to regenerate access token for future usage. 
+    - See [test/example_application_with_refresh_token.py](test/example_application_with_refresh_token.py) for an example with Refresh Token .
 
 ## Documentation for API Endpoints
 

--- a/generator/python/resources/templates/custom/api_client_builder.py.mustache
+++ b/generator/python/resources/templates/custom/api_client_builder.py.mustache
@@ -5,8 +5,8 @@ from {{packageName}} import flow_constants
 class ApiClientBuilder :
 
     @staticmethod
-    def WithClientCredentials(clientId, clientSecret):
-        configuration = Configuration(username=clientId, password=clientSecret)
+    def WithClientCredentials(clientId, clientSecret, host):
+        configuration = Configuration(username=clientId, password=clientSecret, host=host)
 
         return CriteoApiClient(configuration)
 
@@ -16,8 +16,8 @@ class ApiClientBuilder :
         return CriteoApiClient()
 
     @staticmethod
-    def WithAuthorizationCode(clientId, clientSecret, authorization_code, redirect_uri):
-        configuration = Configuration(username=clientId, password=clientSecret)
+    def WithAuthorizationCode(clientId, clientSecret, authorization_code, redirect_uri, host):
+        configuration = Configuration(username=clientId, password=clientSecret, host=host)
         additional_parameters =  {
             'flow' : flow_constants.AUTHORIZATION_CODE_FLOW,
             'authorization_code': authorization_code,
@@ -27,8 +27,8 @@ class ApiClientBuilder :
         return CriteoApiClient(configuration = configuration, additional_parameters = additional_parameters)
 
     @staticmethod
-    def WithRefreshToken(clientId, clientSecret, refreshToken):
-        configuration = Configuration(username=clientId, password=clientSecret)
+    def WithRefreshToken(clientId, clientSecret, refreshToken, host):
+        configuration = Configuration(username=clientId, password=clientSecret, host=host)
         additional_parameters = {
             'flow' : flow_constants.REFRESH_TOKEN_FLOW,
             'refresh_token': refreshToken

--- a/generator/python/resources/templates/custom/api_client_builder.py.mustache
+++ b/generator/python/resources/templates/custom/api_client_builder.py.mustache
@@ -25,3 +25,13 @@ class ApiClientBuilder :
         }
         
         return CriteoApiClient(configuration = configuration, additional_parameters = additional_parameters)
+
+    @staticmethod
+    def WithRefreshToken(clientId, clientSecret, refreshToken):
+        configuration = Configuration(username=clientId, password=clientSecret)
+        additional_parameters = {
+            'flow' : flow_constants.REFRESH_TOKEN_FLOW,
+            'refresh_token': refreshToken
+        }
+
+        return CriteoApiClient(configuration = configuration, additional_parameters = additional_parameters)

--- a/generator/python/resources/templates/custom/api_client_builder.py.mustache
+++ b/generator/python/resources/templates/custom/api_client_builder.py.mustache
@@ -5,7 +5,7 @@ from {{packageName}} import flow_constants
 class ApiClientBuilder :
 
     @staticmethod
-    def WithClientCredentials(clientId, clientSecret, host):
+    def WithClientCredentials(clientId, clientSecret, host=None):
         configuration = Configuration(username=clientId, password=clientSecret, host=host)
 
         return CriteoApiClient(configuration)
@@ -16,7 +16,7 @@ class ApiClientBuilder :
         return CriteoApiClient()
 
     @staticmethod
-    def WithAuthorizationCode(clientId, clientSecret, authorization_code, redirect_uri, host):
+    def WithAuthorizationCode(clientId, clientSecret, authorization_code, redirect_uri, host=None):
         configuration = Configuration(username=clientId, password=clientSecret, host=host)
         additional_parameters =  {
             'flow' : flow_constants.AUTHORIZATION_CODE_FLOW,
@@ -27,7 +27,7 @@ class ApiClientBuilder :
         return CriteoApiClient(configuration = configuration, additional_parameters = additional_parameters)
 
     @staticmethod
-    def WithRefreshToken(clientId, clientSecret, refreshToken, host):
+    def WithRefreshToken(clientId, clientSecret, refreshToken, host=None):
         configuration = Configuration(username=clientId, password=clientSecret, host=host)
         additional_parameters = {
             'flow' : flow_constants.REFRESH_TOKEN_FLOW,

--- a/generator/python/resources/templates/custom/criteo_api_client.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_api_client.py.mustache
@@ -6,3 +6,6 @@ class CriteoApiClient(ApiClient):
              cookie=None, pool_threads=1, additional_parameters= {}):
         super().__init__(configuration=configuration,header_name=header_name, header_value=header_value, cookie=cookie, pool_threads=pool_threads)
         self.rest_client = CriteoRESTClientObject(self.configuration, additional_parameters)
+
+    def get_refresh_token(self):
+        return self.rest_client.get_refresh_token()

--- a/generator/python/resources/templates/custom/criteo_auth.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_auth.py.mustache
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta
 from {{packageName}}.exceptions import ApiException
 from {{packageName}}.api_client import ApiClient
+from {{packageName}} import flow_constants
 
 class Token(object):
 
@@ -87,11 +88,11 @@ class RetryingOAuth(object):
 class RetryingClientCredentials(RetryingOAuth):
     
     def __init__(self, client_id, client_secret):
-        super().__init__('client_credentials', client_id, client_secret)
+        super().__init__(flow_constants.CLIENT_CREDENTIALS_FLOW, client_id, client_secret)
 
 class RetryingAuthorizationCode(RetryingOAuth):
     def __init__(self, client_id, client_secret, code, redirect_uri):
-        super().__init__('authorization_code', client_id, client_secret)
+        super().__init__(flow_constants.AUTHORIZATION_CODE_FLOW, client_id, client_secret)
         self.authorization_code = code
         self.redirect_uri = redirect_uri
 
@@ -105,7 +106,7 @@ class RetryingAuthorizationCode(RetryingOAuth):
 class RetryingRefreshToken(RetryingOAuth):
 
     def __init__(self, client_id, client_secret, refresh_token):
-        super().__init__('refresh_token', client_id, client_secret)
+        super().__init__(flow_constants.REFRESH_TOKEN_FLOW, client_id, client_secret)
         self.refreshToken = refresh_token
 
     def refresh_token(self, client: ApiClient, headers, parameters_dict = {}):

--- a/generator/python/resources/templates/custom/criteo_auth.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_auth.py.mustache
@@ -85,7 +85,6 @@ class RetryingClientCredentials(RetryingOAuth):
         super().__init__('client_credentials', client_id, client_secret)
 
 class RetryingAuthorizationCode(RetryingOAuth):
-   
     def __init__(self, client_id, client_secret, code, redirect_uri):
         super().__init__('authorization_code', client_id, client_secret)
         self.authorization_code = code
@@ -97,3 +96,15 @@ class RetryingAuthorizationCode(RetryingOAuth):
             'redirect_uri' : self.redirect_uri
         })
         return super().refresh_token(client, headers, params)
+    
+class RetryingRefreshToken(RetryingOAuth):
+
+    def __init__(self, client_id, client_secret, refresh_token):
+        super().__init__('refresh_token', client_id, client_secret)
+        self.refresh_token = refresh_token
+
+    def refresh_token(self, client: ApiClient, headers, parameters_dict = {}):
+        params = dict(parameters_dict, **{
+            'refresh_token' : self.refresh_token
+        })
+        return super().refresh_token(client, headers,params)

--- a/generator/python/resources/templates/custom/criteo_auth.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_auth.py.mustache
@@ -29,6 +29,7 @@ class RetryingOAuth(object):
         self.client_id = client_id
         self.client_secret = client_secret
         self.token = None
+        self.refreshToken = None
 
     def get_token(self, client : ApiClient, headers) -> str:    
         if self.token and not self.token.has_expired():
@@ -61,10 +62,14 @@ class RetryingOAuth(object):
             data = json.loads(response.data)
             self.token = Token('Bearer '+ (data['access_token'] or ''),
                RetryingOAuth.compute_expiration_date(data['expires_in']))
-
+            self.refreshToken = data['refresh_token']
+            
             return self.token
         except ApiException as e:
             raise self._enrich_exception_message(e, oauth_url)
+
+    def get_refresh_token(self):
+        return self.refreshToken
 
     def _enrich_exception_message(self, e, url):
         try:
@@ -101,10 +106,10 @@ class RetryingRefreshToken(RetryingOAuth):
 
     def __init__(self, client_id, client_secret, refresh_token):
         super().__init__('refresh_token', client_id, client_secret)
-        self.refresh_token = refresh_token
+        self.refreshToken = refresh_token
 
     def refresh_token(self, client: ApiClient, headers, parameters_dict = {}):
         params = dict(parameters_dict, **{
-            'refresh_token' : self.refresh_token
+            'refresh_token' : self.refreshToken
         })
         return super().refresh_token(client, headers,params)

--- a/generator/python/resources/templates/custom/criteo_auth.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_auth.py.mustache
@@ -35,6 +35,8 @@ class RetryingOAuth(object):
     def get_token(self, client : ApiClient, headers) -> str:    
         if self.token and not self.token.has_expired():
             self.token = None
+            if self.grant_type == flow_constants.AUTHORIZATION_CODE_FLOW:
+                self.grant_type = flow_constants.REFRESH_TOKEN_FLOW
 
         if self.token is None:
             self.refresh_token(client, headers)
@@ -52,6 +54,9 @@ class RetryingOAuth(object):
             'grant_type' : self.grant_type 
             })
         try:
+            if self.grant_type == flow_constants.REFRESH_TOKEN_FLOW:
+                params['refresh_token'] = self.refreshToken
+
             response = client.request('POST', oauth_url,
                                     headers=new_headers,
                                     query_params=[],

--- a/generator/python/resources/templates/custom/criteo_rest.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_rest.py.mustache
@@ -71,3 +71,5 @@ class CriteoRESTClientObject(RESTClientObject):
 
         return super().request(method, url, query_params, headers, body, post_params, _preload_content, _request_timeout)
 
+    def get_refresh_token(self):
+         return self.authorization.get_refresh_token()

--- a/generator/python/resources/templates/custom/criteo_rest.py.mustache
+++ b/generator/python/resources/templates/custom/criteo_rest.py.mustache
@@ -20,6 +20,12 @@ class CriteoRESTClientObject(RESTClientObject):
                 additional_parameters.get('authorization_code',''),
                 additional_parameters.get('redirect_uri','')
             )
+        elif grant_type == flow_constants.REFRESH_TOKEN_FLOW :
+             self.authorization = RetryingRefreshToken(
+                  client_id,
+                  client_secret,
+                  additional_parameters.get('refresh_token', '')
+             )
         else:
             self.authorization = RetryingClientCredentials(
                 client_id,

--- a/generator/python/resources/templates/custom/example_application_with_auth_code.py.mustache
+++ b/generator/python/resources/templates/custom/example_application_with_auth_code.py.mustache
@@ -1,0 +1,27 @@
+from {{packageName}}.api.gateway_api import GatewayApi
+from {{packageName}} import ApiClientBuilder
+
+class ExampleApplication:
+
+    def call_then_application_endpoint(self, clientId, clientSecret, authorization_code, redirect_uri):
+        # Create a client using your choosen OAuth flow, Authorization Code in this case. The client will handle the token generation/renewal for you
+        client = ApiClientBuilder.WithAuthorizationCode(clientId, clientSecret, authorization_code, redirect_uri)
+
+        # The Gateway API regroups common technical endpoints that exists for all versions
+        # You can find the other endpoints in the other *Api
+        # You can reuse the same client with several Apis, but be careful, as they will then use the same token and credentials
+        api = GatewayApi(client)
+
+        # Perform the call to the application introspection endpoint
+        response = api.get_current_application()
+
+        # Most of Criteo's API response follow the same structure:
+        # The response consists of a Data, Errors and Warnings fields
+        # The Data fields contains an Id (if applicable), a Type, and an Attributes field that contains the business object
+        myApplication = response.data.attributes
+        print(f'Hello, I\'m using Criteo API and I\'m connected as {myApplication.name}')
+
+        # You will need to save the refresh_token to use it in the refresh_token flow
+        # You can fetch the refresh token like this:
+        refreshToken = client.get_refresh_token()
+        print('The refresh token to be saved is ', refreshToken)

--- a/generator/python/resources/templates/custom/example_application_with_client_credentials.py.mustache
+++ b/generator/python/resources/templates/custom/example_application_with_client_credentials.py.mustache
@@ -1,13 +1,10 @@
-import logging
-import sys
-
 from {{packageName}}.api.gateway_api import GatewayApi
 from {{packageName}} import ApiClientBuilder
 
 class ExampleApplication:
 
     def call_then_application_endpoint(self, clientId, clientSecret):
-        # Create a client using your choosen OAuth flow. The client will handle the token generation/renewal for you
+        # Create a client using your choosen OAuth flow, Client Credentials in this case. The client will handle the token generation/renewal for you
         client = ApiClientBuilder.WithClientCredentials(clientId=clientId, clientSecret=clientSecret)
 
         # The Gateway API regroups common technical endpoints that exists for all versions

--- a/generator/python/resources/templates/custom/example_application_with_refresh_token.py.mustache
+++ b/generator/python/resources/templates/custom/example_application_with_refresh_token.py.mustache
@@ -1,0 +1,27 @@
+from {{packageName}}.api.gateway_api import GatewayApi
+from {{packageName}} import ApiClientBuilder
+
+class ExampleApplication:
+
+    def call_then_application_endpoint(self, clientId, clientSecret, refresh_token):
+        # Create a client using your choosen OAuth flow, Refresh Token in this case. The client will handle the token generation/renewal for you
+        client = ApiClientBuilder.WithRefreshToken(clientId, clientSecret, refresh_token)
+
+        # The Gateway API regroups common technical endpoints that exists for all versions
+        # You can find the other endpoints in the other *Api
+        # You can reuse the same client with several Apis, but be careful, as they will then use the same token and credentials
+        api = GatewayApi(client)
+
+        # Perform the call to the application introspection endpoint
+        response = api.get_current_application()
+
+        # Most of Criteo's API response follow the same structure:
+        # The response consists of a Data, Errors and Warnings fields
+        # The Data fields contains an Id (if applicable), a Type, and an Attributes field that contains the business object
+        myApplication = response.data.attributes
+        print(f'Hello, I\'m using Criteo API and I\'m connected as {myApplication.name}')
+
+        # You will need to save the new refresh_token to use it again in the future
+        # You can fetch the refresh token like this:
+        refreshToken = client.get_refresh_token()
+        print('The refresh token to be saved is ', refreshToken)

--- a/generator/python/resources/templates/custom/flow_constants.py.mustache
+++ b/generator/python/resources/templates/custom/flow_constants.py.mustache
@@ -2,3 +2,4 @@
 
 CLIENT_CREDENTIALS_FLOW = 'client_credentials'
 AUTHORIZATION_CODE_FLOW = 'authorization_code'
+REFRESH_TOKEN_FLOW = 'refresh_token'

--- a/generator/python/resources/templates/custom/test_gateway_api.py.mustache
+++ b/generator/python/resources/templates/custom/test_gateway_api.py.mustache
@@ -4,7 +4,7 @@ import os
 from {{packageName}}.api.gateway_api import GatewayApi
 from {{packageName}}.api_client_builder import ApiClientBuilder
 from {{packageName}}.rest import ApiException
-from example_application import ExampleApplication
+from example_application_with_client_credentials import ExampleApplication
 
 class TestGatewayApi:
   @pytest.fixture(autouse=True)

--- a/sandbox/python/main.py
+++ b/sandbox/python/main.py
@@ -1,11 +1,10 @@
-import time
-import criteo_api_marketingsolutions_v2022_07 import ApiClientBuilder
+import criteo_api_marketingsolutions_v2022_07
 from criteo_api_marketingsolutions_v2022_07.api import advertiser_api
 from criteo_api_marketingsolutions_v2022_07.model.get_portfolio_response import GetPortfolioResponse
 from pprint import pprint
 
 # Defining the host is optional and defaults to https://api.criteo.com
-    host = "https://api.criteo.com"
+host = "https://api.criteo.com"
 
 # Configure OAuth2 with client credentials
 # refresh token mechanism IS handled for you 💚


### PR DESCRIPTION
This PR consists of the following changes:
- added builder for `refresh_token`
- added method to get the `refresh_token` to be saved somewhere by the user
- `refresh_token` is saved in the client as long as the application is active
- it is also updated automatically when the access_token expires 
- when using `authorization_code` flow initially, the grant type will be automatically changed and the token will be refreshed when the access token expires
- added examples showing the usage of each flow (including just refresh_token_flow)