### PR TITLE
🐛Fix generated gradle script for the java SDK.

### DIFF
--- a/generator/java/resources/templates/build.gradle.mustache
+++ b/generator/java/resources/templates/build.gradle.mustache
@@ -37,9 +37,11 @@ sourceSets {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+// Note: these dependencies should be kept in sync with the ones of the generated pom.xml
 dependencies {
     implementation 'io.swagger:swagger-annotations:1.6.8'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.4'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.8.5'
@@ -47,7 +49,12 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation 'org.glassfish.jersey.core:jersey-client:2.35'
-    testImplementation 'junit:junit:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 task sourcesJar(type: Jar) {

--- a/scripts/languages/java/java_sdk_test_action.py
+++ b/scripts/languages/java/java_sdk_test_action.py
@@ -8,6 +8,7 @@ class JavaSdkTestAction:
   def execute(self, sdk_name):
     self.logger.info(f'Starting testing SDK {sdk_name}...')
 
+    self.logger.info('Testing with the Maven setup !')
     self.logger.info('Installing dependencies...')
     run_command('mvn install', error_template=self.java_error_template)
     self.logger.info('Install successful')
@@ -22,4 +23,17 @@ class JavaSdkTestAction:
 
     self.logger.info('Cleaning package...')
     run_command('mvn clean')
+    self.logger.info('Clean successful')
+
+    self.logger.info('Testing with the Gradle setup !')
+    run_command('chmod u+x ./gradlew')
+    run_command('./gradlew check', error_template=self.java_error_template, env={
+      'TEST_CLIENT_ID': assert_environment_variable('TEST_CLIENT_ID'),
+      'TEST_CLIENT_SECRET': assert_environment_variable('TEST_CLIENT_SECRET'),
+      'TEST_APPLICATION_ID': assert_environment_variable('TEST_APPLICATION_ID'),
+    })
+    self.logger.info('Gradle Check successful')
+
+    self.logger.info('Cleaning package...')
+    run_command('./gradlew clean')
     self.logger.info('Clean successful')


### PR DESCRIPTION
Note: also ensure that the gradle build and test is run as part of the generation tests.

This intends to fix https://github.com/criteo/criteo-api-java-sdk/issues/11