### PR TITLE
Fix 404 in generated doc

### DIFF
--- a/generator/php/generatorConfiguration.yaml
+++ b/generator/php/generatorConfiguration.yaml
@@ -12,6 +12,6 @@ files:
     templateType: SupportingFiles
     destinationFilename: GatewayApiTest.php
   custom/ExampleApplication.php.mustache:
-    folder : lib
+    folder : test
     templateType: SupportingFiles
     destinationFilename: ExampleApplication.php


### PR DESCRIPTION
See https://github.com/criteo/criteo-api-marketingsolutions-php-sdk : it says

> Please see test/ExampleApplication.php for an example on how to
> perform a simple call.

and this has a link to
https://github.com/criteo/criteo-api-marketingsolutions-php-sdk/blob/preview/test/ExampleApplication.php but this file does not exist.

This commit fixes this.