### PR TITLE
Update PHP composer packages

### DIFF
--- a/generator/php/resources/templates/README.mustache
+++ b/generator/php/resources/templates/README.mustache
@@ -20,7 +20,7 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}})
 ## Requirements
 
 This project is tested with PHP 8.0.
-However it should work fine with PHP 7.x too.
+However it should work fine with PHP 7.4 too.
 
 ## Installation & Usage
 

--- a/generator/php/resources/templates/composer.mustache
+++ b/generator/php/resources/templates/composer.mustache
@@ -21,11 +21,12 @@
         "test": "phpunit test/Api"
     },
     "require": {
-        "php": ">=7.1",
+        "php": "^7.4 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/psr7": "^1.7 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=7.4 <10.0",


### PR DESCRIPTION
For some reason we're using a custom template to generate the composer.json file instead of using the one provided by openApiGenerator.

With c5c7ef7d720b73b5456ce67cceaf4223eb58b531 we upgraded openApiGenerator (from 5.2.1 to 6.3.0), but we did not upgraded our composer.mustache in the process.

FTR: the composer template used by openApiGenerator 6.3.0 is available at https://github.com/OpenAPITools/openapi-generator/blob/v6.3.0/modules/openapi-generator/src/main/resources/php/composer.mustache and declares those dependencies

```
"php": "^7.4 || ^8.0",
"ext-curl": "*",
"ext-json": "*",
"ext-mbstring": "*",
"guzzlehttp/guzzle": "^7.3",
"guzzlehttp/psr7": "^1.7 || ^2.0"
```

so the main discrepency with what we generate is the constraint on the version of guzzlehttp/guzzle (that we constrained to be < 7.0.0)

Though the generated code seems to work rather fine, it still means that on the first hand we have generated code designed to work with guzzle 7.3+ but that we constrained another version at runtime.

This also fixes
- https://github.com/criteo/criteo-api-marketingsolutions-php-sdk/issues/6
- and https://github.com/criteo/criteo-api-marketingsolutions-php-sdk/issues/1