### PR TITLE
Fix PHP example (and subsequent test)

### DIFF
--- a/generator/php/generatorConfiguration.yaml
+++ b/generator/php/generatorConfiguration.yaml
@@ -8,7 +8,7 @@ files:
     templateType: SupportingFiles
     destinationFilename: ClientCredentialsClientTest.php
   custom/GatewayApiTest.php.mustache:
-    folder : test
+    folder : test/Api
     templateType: SupportingFiles
     destinationFilename: GatewayApiTest.php
   custom/ExampleApplication.php.mustache:

--- a/generator/php/resources/templates/custom/ExampleApplication.php.mustache
+++ b/generator/php/resources/templates/custom/ExampleApplication.php.mustache
@@ -16,7 +16,7 @@ class ExampleApplication
         //The Gateway API regroups common technical endpoints that exists for all versions
         //You can find the other endpoints in the other *Api
         //You can reuse the same client with several Apis, but be careful, as they will then use the same token and credentials
-        $api = new GatewayApi(client);
+        $api = new GatewayApi($client);
 
         try {
             //Perform the call to the application introspection endpoint

--- a/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
+++ b/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
@@ -8,6 +8,7 @@ use {{invokerPackage}}\ObjectSerializer;
 use {{invokerPackage}}\test\ExampleApplication;
 use Jchook\AssertThrows\AssertThrows;
 use PHPUnit\Framework\TestCase;
+require_once dirname(__FILE__) . '/../ExampleApplication.php';
 
 class GatewayApiTest extends TestCase
 {
@@ -46,8 +47,10 @@ class GatewayApiTest extends TestCase
 
     public function testExampleWorks()
     {
-        $example = new ExampleApplication();
+        $example = new \ExampleApplication();
         $example->CallTheApplicationEndpoint($this->clientId, $this->clientSecret);
+
+        $this->expectNotToPerformAssertions(); // To avoid having a warning saying we did not assert anything
     }
 
     public function testGetCurrentApplicationShouldSucceedWithValidToken()


### PR DESCRIPTION
ExampleApplication was introduced by c0c482d90eaa8c411ea969630546cdb1d6973669. Unfortunately this filed had a typo (fixed by this current commit).

This commit also added a test, in GatewayApiTest, to run this example code. However, this commit also changed the destination of that generated test file, from `test/Api` to `test`.

But we run only tests located in `test/Api` (because of the config in our generated composer.json), which means that since this commit we stopped running test from GatewayApiTest at all.
That explains why this typo was not caught by tests in the first place.

What this current commit does is:
* fix the typo in the example file
* fix the location of the generated GatewayApiTest so those tests are run
* make some required adjustment in the generated test file (namely: importing the file with the example code, and adjusting the namespace to be able to reference the example class)

This fixes
https://github.com/criteo/criteo-api-marketingsolutions-php-sdk/issues/3