### PR TITLE
Rm dead link in README

### DIFF
--- a/generator/php/resources/templates/README.mustache
+++ b/generator/php/resources/templates/README.mustache
@@ -84,10 +84,6 @@ Class | Method | HTTP request | Description
 
 ## Documentation For Authorization
 
-In order to ease usage of this client library, you might want to use the TokenAutoRefreshClient
-as explained in the [example](examples/).
-
-
 {{^authMethods}}
 All endpoints do not require authorization.
 {{/authMethods}}


### PR DESCRIPTION
This link is dead since commit c0c482d90eaa8c411ea969630546cdb1d6973669. Since the README already contains an example which shows how to use ClientCredentialsClient, it seems we just need to delete this link (as opposed to e.g. replacing it with another link)

This fixes
https://github.com/criteo/criteo-api-marketingsolutions-php-sdk/issues/2