### PR TITLE
Fix RM catalog output in python SDK

### DIFF
--- a/api-specifications/retailmedia_2023-04.json
+++ b/api-specifications/retailmedia_2023-04.json
@@ -1242,7 +1242,12 @@
           "200": {
             "description": "Catalog download initiated.",
             "content": {
-              "application/x-json-stream": { },
+              "application/x-json-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
               "application/json": { }
             }
           },

--- a/api-specifications/retailmedia_2023-07.json
+++ b/api-specifications/retailmedia_2023-07.json
@@ -1242,7 +1242,12 @@
           "200": {
             "description": "Catalog download initiated.",
             "content": {
-              "application/x-json-stream": { },
+              "application/x-json-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
               "application/json": { }
             }
           },

--- a/api-specifications/retailmedia_2023-10.json
+++ b/api-specifications/retailmedia_2023-10.json
@@ -1242,7 +1242,12 @@
           "200": {
             "description": "Catalog download initiated.",
             "content": {
-              "application/x-json-stream": { },
+              "application/x-json-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
               "application/json": { }
             }
           },

--- a/api-specifications/retailmedia_2024-01.json
+++ b/api-specifications/retailmedia_2024-01.json
@@ -1242,7 +1242,12 @@
           "200": {
             "description": "Catalog download initiated.",
             "content": {
-              "application/x-json-stream": { },
+              "application/x-json-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
               "application/json": { }
             }
           },

--- a/api-specifications/retailmedia_2024-04.json
+++ b/api-specifications/retailmedia_2024-04.json
@@ -1242,7 +1242,12 @@
           "200": {
             "description": "Catalog download initiated.",
             "content": {
-              "application/x-json-stream": { },
+              "application/x-json-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
               "application/json": { }
             }
           },


### PR DESCRIPTION
Update retail media swagger to make retail-media/catalogs/{catalogId}/output actually download the catalog instead of returning None with the python SDK