### PR TITLE
Fix python generated readme

### DIFF
--- a/api-specifications/marketingsolutions_2024-01.json
+++ b/api-specifications/marketingsolutions_2024-01.json
@@ -9037,6 +9037,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"

--- a/api-specifications/marketingsolutions_2024-04.json
+++ b/api-specifications/marketingsolutions_2024-04.json
@@ -9037,6 +9037,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"

--- a/api-specifications/marketingsolutions_2024-07.json
+++ b/api-specifications/marketingsolutions_2024-07.json
@@ -8989,6 +8989,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"

--- a/api-specifications/marketingsolutions_2024-10.json
+++ b/api-specifications/marketingsolutions_2024-10.json
@@ -8989,6 +8989,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"

--- a/api-specifications/marketingsolutions_2025-01.json
+++ b/api-specifications/marketingsolutions_2025-01.json
@@ -8989,6 +8989,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"

--- a/api-specifications/marketingsolutions_preview.json
+++ b/api-specifications/marketingsolutions_preview.json
@@ -14206,6 +14206,12 @@
             ],
             "type": "string",
             "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the entity (duplicate of the parent id).",
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "campaign read model"
@@ -14540,10 +14546,10 @@
           "lookbackWindow": {
             "enum": [
               "unknown",
-              "sameSession",
-              "twentyFourHours",
-              "sevenDays",
-              "thirtyDays"
+              "30M",
+              "24H",
+              "7D",
+              "30D"
             ],
             "type": "string",
             "description": "The lookback window. Optional, should be specified only for attribution methods PostClick and LastClick.",
@@ -14820,10 +14826,10 @@
           "lookbackWindow": {
             "enum": [
               "unknown",
-              "sameSession",
-              "twentyFourHours",
-              "sevenDays",
-              "thirtyDays"
+              "30M",
+              "24H",
+              "7D",
+              "30D"
             ],
             "type": "string",
             "description": "The lookback window. Optional, should be specified only for attribution methods PostClick and LastClick.",
@@ -15012,10 +15018,10 @@
           "value": {
             "enum": [
               "unknown",
-              "sameSession",
-              "twentyFourHours",
-              "sevenDays",
-              "thirtyDays"
+              "30M",
+              "24H",
+              "7D",
+              "30D"
             ],
             "type": "string",
             "nullable": true,
@@ -20776,17 +20782,31 @@
         "description": "Entity to create a product filter configuration"
       },
       "ProductSet": {
+        "required": [
+          "clientType",
+          "creationDate",
+          "datasetId",
+          "keepVariantProducts",
+          "minimumNumberOfProducts",
+          "name",
+          "numberOfProducts",
+          "rules",
+          "status"
+        ],
         "type": "object",
         "properties": {
           "datasetId": {
             "type": "string",
-            "description": "The dataset to which the product set belong",
-            "nullable": true
+            "description": "The dataset to which the product set belong"
           },
           "name": {
             "type": "string",
-            "description": "The name of the product set",
-            "nullable": true
+            "description": "The name of the product set"
+          },
+          "minimumNumberOfProducts": {
+            "type": "integer",
+            "description": "Minimum amount of products that should match the product set to consider it valid.\r\nGreater or equal than one.",
+            "format": "int32"
           },
           "status": {
             "enum": [
@@ -20798,37 +20818,42 @@
               "Deleted"
             ],
             "type": "string",
-            "description": "The status of the product set",
-            "nullable": true
-          },
-          "isEnabled": {
-            "type": "boolean",
-            "description": "True if the product set is active",
-            "nullable": true
+            "description": "The status of the product set"
           },
           "numberOfProducts": {
             "type": "integer",
-            "description": "The number of product matching the product set",
+            "description": "The number of product matching the product set.\r\nCan be null for newly created product set.",
             "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "x-nullable": true
           },
           "creationDate": {
             "type": "string",
-            "description": "Optional: The creation date of the product set (UTC time in ISO8601 format). Example: \"02/25/2022 14:51:26\"\r\nCan be null if the value doesn't exist.",
-            "nullable": true
+            "description": "The creation date of the product set (UTC time in ISO8601 format). Example: \"02/25/2022 14:51:26\".\r\nCan be null if the value isn't available."
           },
           "rules": {
-            "uniqueItems": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ProductSetRule"
             },
-            "description": "The rules identifying the product belonging to the set",
-            "nullable": true
+            "description": "The rules identifying the product belonging to the set"
+          },
+          "clientType": {
+            "enum": [
+              "Unknown",
+              "CGrowth",
+              "CMax"
+            ],
+            "type": "string",
+            "description": "The client type of the product set"
+          },
+          "keepVariantProducts": {
+            "type": "boolean"
           },
           "id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "x-nullable": true
           }
         },
         "description": "Encapsulate a group of product"

--- a/api-specifications/marketingsolutions_preview.json
+++ b/api-specifications/marketingsolutions_preview.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Criteo API",
     "description": "Criteo API - MarketingSolutions",
-    "version": "preview"
+    "version": "Preview"
   },
   "servers": [
     {
@@ -19561,72 +19561,72 @@
             "format": "date-time"
           },
           "total": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total products at endDate moment",
             "format": "int64"
           },
           "variant": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total variant products at endDate moment",
             "format": "int64"
           },
           "displayable": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total displayable products at endDate moment",
             "format": "int64"
           },
           "nonDisplayable": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total non-displayable products at endDate moment",
             "format": "int64"
           },
           "added": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of inserted products during the period between startDate and endDate",
             "format": "int64"
           },
           "deleted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of deleted products during the period between startDate and endDate",
             "format": "int64"
           },
           "updated": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of updated products during the period between startDate and endDate",
             "format": "int64"
           },
           "blacklisted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total blacklisted products at endDate moment",
             "format": "int64"
           },
           "outOfStock": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total out-of-stock products at endDate moment",
             "format": "int64"
           },
           "missingImage": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total missing image products at endDate moment",
             "format": "int64"
           },
           "missingUrl": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total missing url products at endDate moment",
             "format": "int64"
           },
           "missingPrice": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total missing price products at endDate moment",
             "format": "int64"
           },
           "missingName": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total missing name products at endDate moment",
             "format": "int64"
           },
           "missingDescription": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of total missing description products at endDate moment",
             "format": "int64"
           }
@@ -19671,35 +19671,35 @@
             "description": "The status of the operation.\nThe operation is completed when the status is one of (VALIDATED,VALIDATED_WITH_ERRORS,FAILED)"
           },
           "importRequestTimestamp": {
-            "type": "integer",
+            "type": "string",
             "description": "The date when the original batch request was sent.",
             "format": "int64",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsInTheBatch": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products present in the batch.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsUpserted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products upserted.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsDeleted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products deleted.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsWithErrors": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products with errors.",
             "format": "int32",
             "nullable": true,
@@ -19713,7 +19713,7 @@
             "description": "The list of errors with details."
           },
           "numberOfProductsWithWarnings": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products with Warnings.",
             "format": "int32",
             "nullable": true,

--- a/api-specifications/retailmedia_2024-01.json
+++ b/api-specifications/retailmedia_2024-01.json
@@ -6389,7 +6389,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -9897,10 +9898,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market.",
@@ -10002,15 +10003,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -10799,15 +10800,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -11213,12 +11214,12 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
             "x-nullable": false

--- a/api-specifications/retailmedia_2024-04.json
+++ b/api-specifications/retailmedia_2024-04.json
@@ -6863,7 +6863,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -10491,10 +10492,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market.",
@@ -10596,15 +10597,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -11393,15 +11394,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -11807,12 +11808,12 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
             "x-nullable": false

--- a/api-specifications/retailmedia_2024-07.json
+++ b/api-specifications/retailmedia_2024-07.json
@@ -1207,6 +1207,16 @@
           "204": {
             "description": "Promoted products appended to the line item"
           },
+          "200": {
+            "description": "Promoted products appended to the line item with warnings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResourceOutcome"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Invalid request body",
             "content": {
@@ -7009,9 +7019,9 @@
       },
       "LineItemProductStatus": {
         "enum": [
-          "Unknown",
-          "Active",
-          "Paused"
+          "unknown",
+          "active",
+          "paused"
         ],
         "type": "string",
         "description": "The status of a promoted product in the context of the line item."
@@ -7366,7 +7376,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -10908,10 +10919,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market of the balance.",
@@ -11012,15 +11023,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -11784,15 +11795,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -12198,12 +12209,12 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
             "x-nullable": false

--- a/api-specifications/retailmedia_2024-07.json
+++ b/api-specifications/retailmedia_2024-07.json
@@ -6679,7 +6679,7 @@
             "nullable": true,
             "readOnly": true
           },
-          "metadata": {
+          "meta": {
             "$ref": "#/components/schemas/ProductMetadata"
           },
           "data": {

--- a/api-specifications/retailmedia_2024-10.json
+++ b/api-specifications/retailmedia_2024-10.json
@@ -51,19 +51,17 @@
                   "$ref": "#/components/schemas/RetailMediaContactlistOperation"
                 },
                 "example": {
+                  "type": "AddRemoveContactlistResult",
                   "data": {
-                    "type": "AddRemoveContactlistResult",
-                    "attributes": {
-                      "contactListId": 568708742535471104,
-                      "operation": "add",
-                      "requestDate": "2018-12-10T10:00:50.0000000+00:00",
-                      "identifierType": "madid",
-                      "nbValidIdentifiers": 7343,
-                      "nbInvalidIdentifiers": 13,
-                      "sampleInvalidIdentifiers": [
-                        "InvalidIdentifier"
-                      ]
-                    }
+                    "contactListId": 568708742535471104,
+                    "operation": "add",
+                    "requestDate": "2018-12-10T10:00:50.0000000+00:00",
+                    "identifierType": "madid",
+                    "nbValidIdentifiers": 7343,
+                    "nbInvalidIdentifiers": 13,
+                    "sampleInvalidIdentifiers": [
+                      "InvalidIdentifier"
+                    ]
                   },
                   "errors": [
                     {
@@ -1550,6 +1548,16 @@
         "responses": {
           "204": {
             "description": "Promoted products appended to the line item"
+          },
+          "200": {
+            "description": "Promoted products appended to the line item with warnings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResourceOutcome"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request body",
@@ -5334,6 +5342,12 @@
           "data": {
             "$ref": "#/components/schemas/RetailMediaContactlistOperationResponseAttributes"
           },
+          "type": {
+            "type": "string",
+            "description": "the name of the entity type",
+            "nullable": true,
+            "example": "AddRemoveContactlistResult"
+          },
           "errors": {
             "type": "array",
             "items": {
@@ -5385,68 +5399,53 @@
       },
       "RetailMediaContactlistOperationResponseAttributes": {
         "required": [
-          "attributes",
-          "type"
+          "contactListId",
+          "operation",
+          "requestDate"
         ],
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "description": "the name of the entity type",
-            "example": "AddRemoveContactlistResult"
+          "contactListId": {
+            "type": "integer",
+            "description": "The affected user list id",
+            "format": "int64"
           },
-          "attributes": {
-            "required": [
-              "contactListId",
-              "operation",
-              "requestDate"
-            ],
-            "type": "object",
-            "properties": {
-              "contactListId": {
-                "type": "integer",
-                "description": "The affected user list id",
-                "format": "int64"
-              },
-              "operation": {
-                "type": "string",
-                "description": "The action recorded"
-              },
-              "requestDate": {
-                "type": "string",
-                "description": "When the action was recorded",
-                "format": "date-time"
-              },
-              "identifierType": {
-                "type": "string",
-                "description": "The schema specified for of the identifiers",
-                "nullable": true
-              },
-              "nbInvalidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were invalid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "nbValidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were valid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "sampleInvalidIdentifiers": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "A sample of invalid identifiers if there is some",
-                "nullable": true
-              }
+          "operation": {
+            "type": "string",
+            "description": "The action recorded"
+          },
+          "requestDate": {
+            "type": "string",
+            "description": "When the action was recorded",
+            "format": "date-time"
+          },
+          "identifierType": {
+            "type": "string",
+            "description": "The schema specified for of the identifiers",
+            "nullable": true
+          },
+          "nbInvalidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were invalid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "nbValidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were valid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "sampleInvalidIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "description": "The attributes of Retaile Media contact list operation"
+            "description": "A sample of invalid identifiers if there is some",
+            "nullable": true
           }
         },
-        "description": "Response data of Retail Media contact list operation"
+        "description": "The attributes of Retail Media contact list operation"
       },
       "AudienceError": {
         "required": [
@@ -5570,38 +5569,53 @@
       },
       "RetailMediaContactlistAmendment": {
         "required": [
-          "identifiers",
-          "operation"
+          "attributes"
         ],
         "type": "object",
         "properties": {
-          "operation": {
-            "enum": [
-              "add",
-              "remove"
-            ],
+          "type": {
             "type": "string",
-            "description": "Whether to add or remove users"
+            "description": "User List",
+            "nullable": true,
+            "example": "AddRemoveContactlist"
           },
-          "identifierType": {
-            "enum": [
-              "Email",
-              "UserIdentifier",
-              "IdentityLink",
-              "Gum",
-              "CustomerId",
-              "PhoneNumber"
+          "attributes": {
+            "required": [
+              "identifiers",
+              "operation"
             ],
-            "type": "string",
-            "description": "What type of identifiers are used",
-            "nullable": true
-          },
-          "identifiers": {
-            "type": "array",
-            "items": {
-              "type": "string"
+            "type": "object",
+            "properties": {
+              "operation": {
+                "enum": [
+                  "add",
+                  "remove"
+                ],
+                "type": "string",
+                "description": "Whether to add or remove users"
+              },
+              "identifierType": {
+                "enum": [
+                  "Email",
+                  "UserIdentifier",
+                  "IdentityLink",
+                  "Gum",
+                  "CustomerId",
+                  "PhoneNumber"
+                ],
+                "type": "string",
+                "description": "What type of identifiers are used",
+                "nullable": true
+              },
+              "identifiers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The users to add or remove, each in the schema specified"
+              }
             },
-            "description": "The users to add or remove, each in the schema specified"
+            "description": "Attributes of retail media contact list amendment"
           }
         },
         "description": "Request data of retail media contact list amendment"
@@ -7912,9 +7926,9 @@
       },
       "LineItemProductStatus": {
         "enum": [
-          "Unknown",
-          "Active",
-          "Paused"
+          "unknown",
+          "active",
+          "paused"
         ],
         "type": "string",
         "description": "The status of a promoted product in the context of the line item."
@@ -8269,7 +8283,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -12011,10 +12026,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market of the balance.",
@@ -12115,15 +12130,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -12917,15 +12932,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -13333,12 +13348,12 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
             "x-nullable": false

--- a/api-specifications/retailmedia_2024-10.json
+++ b/api-specifications/retailmedia_2024-10.json
@@ -7586,7 +7586,7 @@
             "nullable": true,
             "readOnly": true
           },
-          "metadata": {
+          "meta": {
             "$ref": "#/components/schemas/ProductMetadata"
           },
           "data": {

--- a/api-specifications/retailmedia_2025-01.json
+++ b/api-specifications/retailmedia_2025-01.json
@@ -7787,7 +7787,7 @@
             "nullable": true,
             "readOnly": true
           },
-          "metadata": {
+          "meta": {
             "$ref": "#/components/schemas/ProductMetadata"
           },
           "data": {

--- a/api-specifications/retailmedia_2025-01.json
+++ b/api-specifications/retailmedia_2025-01.json
@@ -103,19 +103,17 @@
                   "$ref": "#/components/schemas/RetailMediaContactlistOperation"
                 },
                 "example": {
+                  "type": "AddRemoveContactlistResult",
                   "data": {
-                    "type": "AddRemoveContactlistResult",
-                    "attributes": {
-                      "contactListId": 568708742535471104,
-                      "operation": "add",
-                      "requestDate": "2018-12-10T10:00:50.0000000+00:00",
-                      "identifierType": "madid",
-                      "nbValidIdentifiers": 7343,
-                      "nbInvalidIdentifiers": 13,
-                      "sampleInvalidIdentifiers": [
-                        "InvalidIdentifier"
-                      ]
-                    }
+                    "contactListId": 568708742535471104,
+                    "operation": "add",
+                    "requestDate": "2018-12-10T10:00:50.0000000+00:00",
+                    "identifierType": "madid",
+                    "nbValidIdentifiers": 7343,
+                    "nbInvalidIdentifiers": 13,
+                    "sampleInvalidIdentifiers": [
+                      "InvalidIdentifier"
+                    ]
                   },
                   "errors": [
                     {
@@ -1602,6 +1600,16 @@
         "responses": {
           "204": {
             "description": "Promoted products appended to the line item"
+          },
+          "200": {
+            "description": "Promoted products appended to the line item with warnings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResourceOutcome"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request body",
@@ -5535,6 +5543,12 @@
           "data": {
             "$ref": "#/components/schemas/RetailMediaContactlistOperationResponseAttributes"
           },
+          "type": {
+            "type": "string",
+            "description": "the name of the entity type",
+            "nullable": true,
+            "example": "AddRemoveContactlistResult"
+          },
           "errors": {
             "type": "array",
             "items": {
@@ -5586,68 +5600,53 @@
       },
       "RetailMediaContactlistOperationResponseAttributes": {
         "required": [
-          "attributes",
-          "type"
+          "contactListId",
+          "operation",
+          "requestDate"
         ],
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "description": "the name of the entity type",
-            "example": "AddRemoveContactlistResult"
+          "contactListId": {
+            "type": "integer",
+            "description": "The affected user list id",
+            "format": "int64"
           },
-          "attributes": {
-            "required": [
-              "contactListId",
-              "operation",
-              "requestDate"
-            ],
-            "type": "object",
-            "properties": {
-              "contactListId": {
-                "type": "integer",
-                "description": "The affected user list id",
-                "format": "int64"
-              },
-              "operation": {
-                "type": "string",
-                "description": "The action recorded"
-              },
-              "requestDate": {
-                "type": "string",
-                "description": "When the action was recorded",
-                "format": "date-time"
-              },
-              "identifierType": {
-                "type": "string",
-                "description": "The schema specified for of the identifiers",
-                "nullable": true
-              },
-              "nbInvalidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were invalid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "nbValidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were valid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "sampleInvalidIdentifiers": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "A sample of invalid identifiers if there is some",
-                "nullable": true
-              }
+          "operation": {
+            "type": "string",
+            "description": "The action recorded"
+          },
+          "requestDate": {
+            "type": "string",
+            "description": "When the action was recorded",
+            "format": "date-time"
+          },
+          "identifierType": {
+            "type": "string",
+            "description": "The schema specified for of the identifiers",
+            "nullable": true
+          },
+          "nbInvalidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were invalid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "nbValidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were valid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "sampleInvalidIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "description": "The attributes of Retaile Media contact list operation"
+            "description": "A sample of invalid identifiers if there is some",
+            "nullable": true
           }
         },
-        "description": "Response data of Retail Media contact list operation"
+        "description": "The attributes of Retail Media contact list operation"
       },
       "AudienceError": {
         "required": [
@@ -5771,38 +5770,53 @@
       },
       "RetailMediaContactlistAmendment": {
         "required": [
-          "identifiers",
-          "operation"
+          "attributes"
         ],
         "type": "object",
         "properties": {
-          "operation": {
-            "enum": [
-              "add",
-              "remove"
-            ],
+          "type": {
             "type": "string",
-            "description": "Whether to add or remove users"
+            "description": "User List",
+            "nullable": true,
+            "example": "AddRemoveContactlist"
           },
-          "identifierType": {
-            "enum": [
-              "Email",
-              "UserIdentifier",
-              "IdentityLink",
-              "Gum",
-              "CustomerId",
-              "PhoneNumber"
+          "attributes": {
+            "required": [
+              "identifiers",
+              "operation"
             ],
-            "type": "string",
-            "description": "What type of identifiers are used",
-            "nullable": true
-          },
-          "identifiers": {
-            "type": "array",
-            "items": {
-              "type": "string"
+            "type": "object",
+            "properties": {
+              "operation": {
+                "enum": [
+                  "add",
+                  "remove"
+                ],
+                "type": "string",
+                "description": "Whether to add or remove users"
+              },
+              "identifierType": {
+                "enum": [
+                  "Email",
+                  "UserIdentifier",
+                  "IdentityLink",
+                  "Gum",
+                  "CustomerId",
+                  "PhoneNumber"
+                ],
+                "type": "string",
+                "description": "What type of identifiers are used",
+                "nullable": true
+              },
+              "identifiers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The users to add or remove, each in the schema specified"
+              }
             },
-            "description": "The users to add or remove, each in the schema specified"
+            "description": "Attributes of retail media contact list amendment"
           }
         },
         "description": "Request data of retail media contact list amendment"
@@ -8113,9 +8127,9 @@
       },
       "LineItemProductStatus": {
         "enum": [
-          "Unknown",
-          "Active",
-          "Paused"
+          "unknown",
+          "active",
+          "paused"
         ],
         "type": "string",
         "description": "The status of a promoted product in the context of the line item."
@@ -8497,7 +8511,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -12421,10 +12436,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market of the balance.",
@@ -12525,15 +12540,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -13327,15 +13342,15 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
-            "default": "None",
+            "default": "none",
             "x-nullable": false
           },
           "name": {
@@ -13743,12 +13758,12 @@
           },
           "viewAttributionWindow": {
             "enum": [
-              "None",
-              "Unknown",
-              "OneDay",
-              "SevenDays",
-              "FourteenDays",
-              "ThirtyDays"
+              "none",
+              "unknown",
+              "1D",
+              "7D",
+              "14D",
+              "30D"
             ],
             "type": "string",
             "x-nullable": false

--- a/api-specifications/retailmedia_preview.json
+++ b/api-specifications/retailmedia_preview.json
@@ -103,19 +103,17 @@
                   "$ref": "#/components/schemas/RetailMediaContactlistOperation"
                 },
                 "example": {
+                  "type": "AddRemoveContactlistResult",
                   "data": {
-                    "type": "AddRemoveContactlistResult",
-                    "attributes": {
-                      "contactListId": 568708742535471104,
-                      "operation": "add",
-                      "requestDate": "2018-12-10T10:00:50.0000000+00:00",
-                      "identifierType": "madid",
-                      "nbValidIdentifiers": 7343,
-                      "nbInvalidIdentifiers": 13,
-                      "sampleInvalidIdentifiers": [
-                        "InvalidIdentifier"
-                      ]
-                    }
+                    "contactListId": 568708742535471104,
+                    "operation": "add",
+                    "requestDate": "2018-12-10T10:00:50.0000000+00:00",
+                    "identifierType": "madid",
+                    "nbValidIdentifiers": 7343,
+                    "nbInvalidIdentifiers": 13,
+                    "sampleInvalidIdentifiers": [
+                      "InvalidIdentifier"
+                    ]
                   },
                   "errors": [
                     {
@@ -1469,6 +1467,16 @@
         "responses": {
           "204": {
             "description": "Promoted products appended to the line item"
+          },
+          "200": {
+            "description": "Promoted products appended to the line item with warnings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResourceOutcome"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request body",
@@ -3347,17 +3355,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfRetailMediaSeller"
+                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfSellerSearchResult"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfRetailMediaSeller"
+                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfSellerSearchResult"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfRetailMediaSeller"
+                  "$ref": "#/components/schemas/ValueResourceCollectionOutcomeOfSellerSearchResult"
                 }
               }
             }
@@ -4518,6 +4526,12 @@
           "data": {
             "$ref": "#/components/schemas/RetailMediaContactlistOperationResponseAttributes"
           },
+          "type": {
+            "type": "string",
+            "description": "the name of the entity type",
+            "nullable": true,
+            "example": "AddRemoveContactlistResult"
+          },
           "errors": {
             "type": "array",
             "items": {
@@ -4569,68 +4583,53 @@
       },
       "RetailMediaContactlistOperationResponseAttributes": {
         "required": [
-          "attributes",
-          "type"
+          "contactListId",
+          "operation",
+          "requestDate"
         ],
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "description": "the name of the entity type",
-            "example": "AddRemoveContactlistResult"
+          "contactListId": {
+            "type": "integer",
+            "description": "The affected user list id",
+            "format": "int64"
           },
-          "attributes": {
-            "required": [
-              "contactListId",
-              "operation",
-              "requestDate"
-            ],
-            "type": "object",
-            "properties": {
-              "contactListId": {
-                "type": "integer",
-                "description": "The affected user list id",
-                "format": "int64"
-              },
-              "operation": {
-                "type": "string",
-                "description": "The action recorded"
-              },
-              "requestDate": {
-                "type": "string",
-                "description": "When the action was recorded",
-                "format": "date-time"
-              },
-              "identifierType": {
-                "type": "string",
-                "description": "The schema specified for of the identifiers",
-                "nullable": true
-              },
-              "nbInvalidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were invalid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "nbValidIdentifiers": {
-                "type": "integer",
-                "description": "How many identifiers were valid for the specified schema",
-                "format": "int32",
-                "nullable": true
-              },
-              "sampleInvalidIdentifiers": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "A sample of invalid identifiers if there is some",
-                "nullable": true
-              }
+          "operation": {
+            "type": "string",
+            "description": "The action recorded"
+          },
+          "requestDate": {
+            "type": "string",
+            "description": "When the action was recorded",
+            "format": "date-time"
+          },
+          "identifierType": {
+            "type": "string",
+            "description": "The schema specified for of the identifiers",
+            "nullable": true
+          },
+          "nbInvalidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were invalid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "nbValidIdentifiers": {
+            "type": "integer",
+            "description": "How many identifiers were valid for the specified schema",
+            "format": "int32",
+            "nullable": true
+          },
+          "sampleInvalidIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "description": "The attributes of Retaile Media contact list operation"
+            "description": "A sample of invalid identifiers if there is some",
+            "nullable": true
           }
         },
-        "description": "Response data of Retail Media contact list operation"
+        "description": "The attributes of Retail Media contact list operation"
       },
       "AudienceError": {
         "required": [
@@ -4754,38 +4753,53 @@
       },
       "RetailMediaContactlistAmendment": {
         "required": [
-          "identifiers",
-          "operation"
+          "attributes"
         ],
         "type": "object",
         "properties": {
-          "operation": {
-            "enum": [
-              "add",
-              "remove"
-            ],
+          "type": {
             "type": "string",
-            "description": "Whether to add or remove users"
+            "description": "User List",
+            "nullable": true,
+            "example": "AddRemoveContactlist"
           },
-          "identifierType": {
-            "enum": [
-              "Email",
-              "UserIdentifier",
-              "IdentityLink",
-              "Gum",
-              "CustomerId",
-              "PhoneNumber"
+          "attributes": {
+            "required": [
+              "identifiers",
+              "operation"
             ],
-            "type": "string",
-            "description": "What type of identifiers are used",
-            "nullable": true
-          },
-          "identifiers": {
-            "type": "array",
-            "items": {
-              "type": "string"
+            "type": "object",
+            "properties": {
+              "operation": {
+                "enum": [
+                  "add",
+                  "remove"
+                ],
+                "type": "string",
+                "description": "Whether to add or remove users"
+              },
+              "identifierType": {
+                "enum": [
+                  "Email",
+                  "UserIdentifier",
+                  "IdentityLink",
+                  "Gum",
+                  "CustomerId",
+                  "PhoneNumber"
+                ],
+                "type": "string",
+                "description": "What type of identifiers are used",
+                "nullable": true
+              },
+              "identifiers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The users to add or remove, each in the schema specified"
+              }
             },
-            "description": "The users to add or remove, each in the schema specified"
+            "description": "Attributes of retail media contact list amendment"
           }
         },
         "description": "Request data of retail media contact list amendment"
@@ -7790,9 +7804,9 @@
       },
       "LineItemProductStatus": {
         "enum": [
-          "Unknown",
-          "Active",
-          "Paused"
+          "unknown",
+          "active",
+          "paused"
         ],
         "type": "string",
         "description": "The status of a promoted product in the context of the line item."
@@ -8608,7 +8622,8 @@
           "currency": {
             "type": "string",
             "description": "An ISO4217 representation of the currency products are listed under in this catalog.",
-            "x-nullable": false
+            "nullable": true,
+            "x-nullable": true
           },
           "rowCount": {
             "type": "integer",
@@ -11399,13 +11414,13 @@
         },
         "description": "Line Items report body request"
       },
-      "ValueResourceCollectionOutcomeOfRetailMediaSeller": {
+      "ValueResourceCollectionOutcomeOfSellerSearchResult": {
         "type": "object",
         "properties": {
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ValueResourceOfRetailMediaSeller"
+              "$ref": "#/components/schemas/ValueResourceOfSellerSearchResult"
             },
             "nullable": true
           },
@@ -11512,7 +11527,7 @@
         "additionalProperties": false,
         "description": "A top-level object that encapsulates a Criteo API request for a single value objects."
       },
-      "ValueResourceOfRetailMediaSeller": {
+      "ValueResourceOfSellerSearchResult": {
         "type": "object",
         "properties": {
           "type": {
@@ -11521,7 +11536,7 @@
             "nullable": true
           },
           "attributes": {
-            "$ref": "#/components/schemas/RetailMediaSeller"
+            "$ref": "#/components/schemas/SellerSearchResult"
           }
         },
         "additionalProperties": false,
@@ -11629,28 +11644,25 @@
         "additionalProperties": false,
         "description": "A value resource exposed by the API."
       },
-      "RetailMediaSeller": {
+      "SellerSearchResult": {
         "type": "object",
         "properties": {
-          "sellerId": {
+          "accountId": {
             "type": "string",
-            "description": "the seller id",
+            "description": "the id for the account",
             "nullable": true
           },
-          "retailerId": {
-            "type": "integer",
-            "description": "the retailer id",
-            "format": "int32",
-            "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "description": "seller name",
+          "sellers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RetailMediaSeller"
+            },
+            "description": "the details for mapped sellers for the account",
             "nullable": true
           }
         },
         "additionalProperties": false,
-        "description": "used to define the exact seller linked with an account"
+        "description": "holds an AccountId and the mapped seller information for that account"
       },
       "ChangeDetailsV1": {
         "type": "object",
@@ -11720,6 +11732,29 @@
         },
         "additionalProperties": false,
         "description": "request body for the seller search endpoint"
+      },
+      "RetailMediaSeller": {
+        "type": "object",
+        "properties": {
+          "sellerId": {
+            "type": "string",
+            "description": "the seller id",
+            "nullable": true
+          },
+          "retailerId": {
+            "type": "integer",
+            "description": "the retailer id",
+            "format": "int32",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "seller name",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "used to define the exact seller linked with an account"
       },
       "Keywords": {
         "type": "object",
@@ -12449,10 +12484,10 @@
           },
           "privateMarketBillingType": {
             "enum": [
-              "NotApplicable",
-              "BillByRetailer",
-              "BillByCriteo",
-              "Unknown"
+              "notApplicable",
+              "billByRetailer",
+              "billByCriteo",
+              "unknown"
             ],
             "type": "string",
             "description": "Billing type for Private Market of the balance.",

--- a/api-specifications/retailmedia_preview.json
+++ b/api-specifications/retailmedia_preview.json
@@ -4452,17 +4452,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResult"
+                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResultPagingOffsetLimitMetadata"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResult"
+                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResultPagingOffsetLimitMetadata"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResult"
+                  "$ref": "#/components/schemas/EntityResourceCollectionOutcomeBrandIdSearchResultPagingOffsetLimitMetadata"
                 }
               }
             }
@@ -5219,35 +5219,35 @@
             "description": "The status of the operation.\nThe operation is completed when the status is one of (VALIDATED,VALIDATED_WITH_ERRORS,FAILED)"
           },
           "importRequestTimestamp": {
-            "type": "integer",
+            "type": "string",
             "description": "The date when the original batch request was sent.",
             "format": "int64",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsInTheBatch": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products present in the batch.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsUpserted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products upserted.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsDeleted": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products deleted.",
             "format": "int32",
             "nullable": true,
             "x-nullable": true
           },
           "numberOfProductsWithErrors": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products with errors.",
             "format": "int32",
             "nullable": true,
@@ -5261,7 +5261,7 @@
             "description": "The list of errors with details."
           },
           "numberOfProductsWithWarnings": {
-            "type": "integer",
+            "type": "string",
             "description": "The number of products with Warnings.",
             "format": "int32",
             "nullable": true,
@@ -7464,7 +7464,7 @@
             "nullable": true,
             "readOnly": true
           },
-          "metadata": {
+          "meta": {
             "$ref": "#/components/schemas/ProductMetadata"
           },
           "data": {
@@ -13122,9 +13122,12 @@
         "description": "Category information for a preferred line item page",
         "x-nullable": false
       },
-      "EntityResourceCollectionOutcomeBrandIdSearchResult": {
+      "EntityResourceCollectionOutcomeBrandIdSearchResultPagingOffsetLimitMetadata": {
         "type": "object",
         "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PagingOffsetLimitMetadata"
+          },
           "data": {
             "type": "array",
             "items": {
@@ -13152,7 +13155,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "A top-level object that encapsulates a Criteo API response for several entities."
+        "description": "A top-level object that encapsulates a Criteo API response for several entities and metadata."
       },
       "ValueResourceInputBrandIdSearchRequest": {
         "type": "object",
@@ -13163,6 +13166,32 @@
         },
         "additionalProperties": false,
         "description": "A top-level object that encapsulates a Criteo API request for a single value objects."
+      },
+      "PagingOffsetLimitMetadata": {
+        "required": [
+          "limit",
+          "offset"
+        ],
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "offset": {
+            "type": "integer",
+            "description": "The (zero-based) starting offset in the collection.",
+            "format": "int32"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "The number of elements to be returned.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Metadata for paging data."
       },
       "EntityResourceBrandIdSearchResult": {
         "type": "object",
@@ -13233,16 +13262,19 @@
         "description": "An object that represents the result from a brand ID search."
       },
       "BrandIdSearchRequest": {
+        "required": [
+          "retailerIds"
+        ],
         "type": "object",
         "properties": {
           "retailerIds": {
+            "minItems": 1,
             "type": "array",
             "items": {
               "type": "integer",
               "format": "int32"
             },
-            "description": "IDs of the retailers we want to limit the search to",
-            "nullable": true
+            "description": "IDs of the retailers we want to limit the search to"
           },
           "name": {
             "type": "string",

--- a/generator/python/resources/templates/README.mustache
+++ b/generator/python/resources/templates/README.mustache
@@ -62,8 +62,8 @@ All URIs are relative to *{{basePath}}*.
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-{{#apiInfo}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
-{{/operation}}{{/operations}}{{/apiInfo}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
+{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 ## Documentation For Models
 


### PR DESCRIPTION
Template fix for the README at root of each SDK Python package: currently the mapping table between SDK method and API endpoint is empty (see e.g., https://github.com/criteo/criteo-api-python-sdk/tree/main/sdks/marketingsolutions_2024-01#documentation-for-api-endpoints)