### PR TITLE
fix(java): update sonartype repository URLs

### DIFF
--- a/generator/java/resources/templates/build.gradle.mustache
+++ b/generator/java/resources/templates/build.gradle.mustache
@@ -122,6 +122,8 @@ nexusPublishing {
     packageGroup = '{{groupId}}'
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username = "criteo-oss"
             password = System.getenv("SONATYPE_PASSWORD")
         }


### PR DESCRIPTION
OSSRH has been sunset:
https://central.sonatype.org/news/20250326_ossrh_sunset/

Legacy plugins support via staging API:
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuring-your-plugin