### PR TITLE
✅ Fix SDK test by updating content of 401 response for GET /me

### DIFF
--- a/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
+++ b/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
@@ -98,8 +98,8 @@ class GatewayApiTest extends TestCase
 
                 // Assert
                 $this->assertEquals(401, $exception->getCode());
-                $this->assertEquals('authentication', $data->getErrors()[0]->getType());
-                $this->assertEquals('authentication-required', $data->getErrors()[0]->getCode());
+                $this->assertEquals('authorization', $data->getErrors()[0]->getType());
+                $this->assertEquals('authorization-token-missing', $data->getErrors()[0]->getCode());
             }
         );
     }

--- a/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
+++ b/generator/php/resources/templates/custom/GatewayApiTest.php.mustache
@@ -99,7 +99,7 @@ class GatewayApiTest extends TestCase
                 // Assert
                 $this->assertEquals(401, $exception->getCode());
                 $this->assertEquals('authorization', $data->getErrors()[0]->getType());
-                $this->assertEquals('authorization-token-missing', $data->getErrors()[0]->getCode());
+                $this->assertEquals('authorization-token-invalid', $data->getErrors()[0]->getCode());
             }
         );
     }


### PR DESCRIPTION
Get */me endpoint returns a different body for 401 responses compared to what is expected in the test, example:

```
{
  "warnings": [],
  "errors": [
    {
      "traceId": "ec035ee3e7483161d6640df66f0f842b",
      "traceIdentifier": "ec035ee3e7483161d6640df66f0f842b",
      "type": "authorization",
      "code": "authorization-token-missing",
      "instance": "/api/v1/me",
      "title": "The authorization header is missing"
    }
  ]
}
```