### PR TITLE
🔧 Add --no-cleanup flag to support release candidate version onboarding

### DIFF
--- a/.github/workflows/update_oas.yml
+++ b/.github/workflows/update_oas.yml
@@ -5,7 +5,11 @@ on:
     inputs:
         latest-version:
           type: string
-          description: latest stable API version (ex 2023-07)
+          description: latest API version to onboard (ex 2026-07)
+        release-candidate:
+          type: boolean
+          description: skip cleanup of obsolete versions (use for release candidates)
+          default: false
 
 permissions:
   actions: write
@@ -24,7 +28,12 @@ jobs:
           python-version: '3.9'
 
       - name: update OAS
-        run: python scripts/update_specification_files.py -s api-specifications -g https://api.criteo.com -r ${{ github.event.inputs.latest-version }}
+        run: |
+          EXTRA_ARGS=""
+          if [ "${{ github.event.inputs.release-candidate }}" == "true" ]; then
+            EXTRA_ARGS="--no-cleanup"
+          fi
+          python scripts/update_specification_files.py -s api-specifications -g https://api.criteo.com -r ${{ github.event.inputs.latest-version }} $EXTRA_ARGS
 
       - name: Create new branch and commit files
         run: |
@@ -32,10 +41,10 @@ jobs:
           git config --global user.email "update-oas-bot]@users.noreply.github.com"
           git checkout -b update-oas-$(date --rfc-3339=date)
           git add *
-          git commit -m "Update OAS up to ${{ github.event.inputs.latest-version }}"
+          git commit -m "Update OAS for ${{ github.event.inputs.latest-version }}${{ github.event.inputs.release-candidate == 'true' && ' (RC)' || '' }}"
           git push origin update-oas-$(date --rfc-3339=date)
 
       - name: Create pull request on main
-        run: gh pr create --base main --head update-oas-$(date --rfc-3339=date) --title "Update OAS up to ${{ github.event.inputs.latest-version }}" --body "Update OAS up to ${{ github.event.inputs.latest-version }}"
+        run: gh pr create --base main --head update-oas-$(date --rfc-3339=date) --title "Update OAS for ${{ github.event.inputs.latest-version }}${{ github.event.inputs.release-candidate == 'true' && ' (RC)' || '' }}" --body "Update OAS for ${{ github.event.inputs.latest-version }}${{ github.event.inputs.release-candidate == 'true' && ' (RC — no version cleanup performed)' || '' }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/update_specification_files.py
+++ b/scripts/update_specification_files.py
@@ -85,19 +85,22 @@ def update_previous_specifications(specification_folder, gateway_service):
 
 
 def main():
-    help_msg = f'{__doc__}\n{__file__} -r <version to release> -s <path to specification folder> -g <URL to the gateway service>'
+    help_msg = f'{__doc__}\n{__file__} -r <version to release> -s <path to specification folder> -g <URL to the gateway service> [-n] (skip cleanup of obsolete versions, use for release candidates)'
     try:
-        opts, _ = getopt.getopt(sys.argv[1:], "hvr:s:g:", ["help", "verbose", "release=", "specification_folder=", "gateway_service="])
+        opts, _ = getopt.getopt(sys.argv[1:], "hvnr:s:g:", ["help", "verbose", "no-cleanup", "release=", "specification_folder=", "gateway_service="])
     except getopt.GetoptError:
         LOGGER.error(f'Invalid call: [help] {help_msg}')
         sys.exit(2)
 
+    no_cleanup = False
     for option, value in opts:
         if option in ('-h', '--help'):
             LOGGER.info(help_msg)
             sys.exit()
         elif option in ('-v', ):
            LOGGER.setLevel(logging.DEBUG)
+        elif option in ('-n', '--no-cleanup'):
+            no_cleanup = True
         elif option in ('-r', '--release'):
             release = value
         elif option in ('-s', '--specification_folder'):
@@ -107,7 +110,7 @@ def main():
         else:
             raise Exception(f'Unsupported command line option ({option}={value}).')
 
-    if release.lower() == "preview":
+    if release.lower() == "preview" or no_cleanup:
       for api_service in ALL_API_SERVICES:
           LOGGER.info(f"Getting new specifications for {api_service}/{release}")
           download_specification(release, api_service, specification_folder, gateway_service)


### PR DESCRIPTION
Adds a [-n/--no-cleanup] flag tthat skips deletion of obsolete specs and re-download of existing versions, only downloading the new version. Exposes this as a release-candidate checkbox in the update_oas.yml workflow dispatch UI.

JIRA: https://criteo.atlassian.net/browse/TECHNO-1829