### PR TITLE
🔧 Add experimental support (A.K.A preview version replacement)

### DIFF
--- a/.github/workflows/auto_update_experimental.yml
+++ b/.github/workflows/auto_update_experimental.yml
@@ -1,0 +1,71 @@
+name: Weekly autoupdate OAS for Experimental
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # At 16:00 on every Monday
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-oas:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.CRITEO_API_SDK_GENERATOR_REPO_PRIVATE_KEY }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+
+      - name: Update OAS
+        run: python scripts/update_specification_files.py -s api-specifications -g https://api.criteo.com -r Experimental
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git add *
+          if git diff --cached --exit-code; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push files
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git config --global user.name "update-oas-bot"
+          git config --global user.email "update-oas-bot@users.noreply.github.com"
+          git commit -m "Update OAS for Experimental"
+          git push origin HEAD:main
+
+      - name: Send success notification
+        if: ${{ success() && steps.check_changes.outputs.has_changes == 'true' }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            status: "${{ job.status }}"
+            channel: "C02J0CWR789"
+            username: "sdk-generation-bot"
+            text: "Autoupdate of OAS in Experimental. Autoupdate of OAS in experimental runs weekly on Monday."
+            icon_emoji: ":bell:"
+
+      - name: Send failure notification
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            status: "${{ job.status }}"
+            channel: "C02J0CWR789"
+            username: "sdk-generation-bot"
+            text: "Autoupdate of OAS in Experimental failure, check <https://github.com/criteo/criteo-api-sdk-generator/actions|action results>. <!subteam^S07BSM1MDN2>."
+            icon_emoji: ":x:"

--- a/generator/java/build.gradle
+++ b/generator/java/build.gradle
@@ -44,7 +44,7 @@ task generateClient(type: GradleBuild) {
 
         def clientOutputDirPerVersion = clientOutputDir + "/" + parsedApiName;
         def specPath = it.path;
-        def isPreviewVersion = criteoApiVersion == 'preview';
+        def isPreviewOrExperimental = criteoApiVersion == 'preview' || criteoApiVersion == 'experimental';
 
         def versionInNamespace =  criteoApiVersion
         if (versionInNamespace.matches("[0-9].*"))
@@ -52,7 +52,7 @@ task generateClient(type: GradleBuild) {
 
         def namespaceBase = "${criteoPackage}.${criteoService}.${versionInNamespace}".replace('.', nameSeparator).toString(); // example : criteo.api.marketingsolutions.v2021_10
 
-        def artifactVersion = isPreviewVersion ? '0' : criteoApiVersion.replaceAll("_",".").toString()
+        def artifactVersion = isPreviewOrExperimental ? '0' : criteoApiVersion.replaceAll("_",".").toString()
         artifactVersion += ".${generatorVersion}.${getFormattedDate()}".toString() // example : 2021.01.0.211110 for stable , 0.0.211110 for preview
 
         namespaceBase = "com." + namespaceBase; // 'com' is Java-specific => example: com.criteo.api.marketingsolutions.v2021_10

--- a/generator/php/build.gradle
+++ b/generator/php/build.gradle
@@ -46,15 +46,15 @@ task generateClient(type: GradleBuild) {
         
         def clientOutputDirPerVersion = clientOutputDir + "/" + parsedApiName;
         def specPath = it.path;
-        def isPreviewVersion = criteoApiVersion == 'preview';
-  
+        def isPreviewOrExperimental = criteoApiVersion == 'preview' || criteoApiVersion == 'experimental';
+
         def versionInNamespace =  criteoApiVersion
         if (versionInNamespace.matches("[0-9].*"))
              versionInNamespace= "v" + versionInNamespace
 
         def namespaceBase = "${criteoPackage}.${criteoService}.${versionInNamespace}".replace('.', nameSeparator).toString(); // example: criteo\api\marketingsolutions\v2021_10
-        
-        def artifactVersion = isPreviewVersion ? '0' : criteoApiVersion.replaceAll("_",".").toString()
+
+        def artifactVersion = isPreviewOrExperimental ? '0' : criteoApiVersion.replaceAll("_",".").toString()
         artifactVersion += ".${generatorVersion}.${getFormattedDate()}".toString() // example : 2021.01.0.211110 for stable , 0.0.211110 for preview
 
         def generateTask = task("openApiGenerate_${technologyStack}_" + parsedApiName, type: GenerateTask.class) {

--- a/generator/python/build.gradle
+++ b/generator/python/build.gradle
@@ -49,15 +49,15 @@ task generateClient(type: GradleBuild) {
         
         def clientOutputDirPerVersion = clientOutputDir + "/" + parsedApiName;
         def specPath = it.path;
-        def isPreviewVersion = criteoApiVersion == 'preview';
-  
+        def isPreviewOrExperimental = criteoApiVersion == 'preview' || criteoApiVersion == 'experimental';
+
         def versionInNamespace =  criteoApiVersion
         if (versionInNamespace.matches("[0-9].*"))
              versionInNamespace= "v" + versionInNamespace
 
         def namespaceBase = "${criteoPackage}.${criteoService}.${versionInNamespace}".replace('.', nameSeparator).toString(); // example: criteo_api_marketingsolutions_v2021_10
-        
-        def artifactVersion = isPreviewVersion ? '0' : criteoApiVersion.replaceAll("_",".").toString()
+
+        def artifactVersion = isPreviewOrExperimental ? '0' : criteoApiVersion.replaceAll("_",".").toString()
         artifactVersion += ".${generatorVersion}.${getFormattedDate()}".toString() // example : 2021.01.0.211110 for stable , 0.0.211110 for preview
 
         def createConfig  = task("createConfig_" + taskSuffix, type: Copy)

--- a/scripts/languages/php/php_sdk_push_action.py
+++ b/scripts/languages/php/php_sdk_push_action.py
@@ -5,7 +5,7 @@ from shared.clients.os_client import IOsClient
 
 from shared.clients.git_client import GitException, IGitClient
 from shared.models.programming_language import ProgrammingLanguage
-from shared.utils import get_logger, assert_criteo_service, assert_api_version, get_formatted_date
+from shared.utils import get_logger, assert_criteo_service, assert_api_version, get_formatted_date, PREVIEW_AND_EXPERIMENTAL_VERSIONS
 
 logger = get_logger()
 
@@ -132,7 +132,7 @@ class PhpSdkPushAction:
   def __get_tag_name(self, patch=0):
       now_date = get_formatted_date()
 
-      if self.api_version == 'preview':
+      if self.api_version in PREVIEW_AND_EXPERIMENTAL_VERSIONS:
         api_version = 0
       else:
         api_version = self.api_version.replace('-', '.')

--- a/scripts/shared/utils.py
+++ b/scripts/shared/utils.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime
 from .models.criteo_service import CriteoService
 
+PREVIEW_AND_EXPERIMENTAL_VERSIONS = {'preview', 'experimental'}
+
 logger = None
 formatted_date = None
 
@@ -35,7 +37,7 @@ def assert_api_version(directory_name):
 
   api_version = splitted_directory_name[1]
 
-  if api_version != 'preview' and not re.match(r'[0-9]{2,}(-[0-9]{2})', api_version):
+  if api_version not in PREVIEW_AND_EXPERIMENTAL_VERSIONS and not re.match(r'[0-9]{2,}(-[0-9]{2})', api_version):
     raise InvalidApiVersionException(f'API Version found in directory name of generated source is invalid ({api_version})')
   
   return api_version

--- a/scripts/tests/languages/php/test_php_sdk_push_action.py
+++ b/scripts/tests/languages/php/test_php_sdk_push_action.py
@@ -111,6 +111,9 @@ class TestPhpSdkPushAction:
     ('preview', 0, f'0.0.{get_formatted_date()}'),
     ('preview', 1, f'0.0.{get_formatted_date()}-patch1'),
     ('preview', 99, f'0.0.{get_formatted_date()}-patch99'),
+    ('experimental', 0, f'0.0.{get_formatted_date()}'),
+    ('experimental', 1, f'0.0.{get_formatted_date()}-patch1'),
+    ('experimental', 99, f'0.0.{get_formatted_date()}-patch99'),
     ('2021-10', 0, f'2021.10.0.{get_formatted_date()}'),
     ('2021-10', 1, f'2021.10.0.{get_formatted_date()}-patch1'),
     ('2021-10', 99, f'2021.10.0.{get_formatted_date()}-patch99'),
@@ -141,6 +144,7 @@ class TestPhpSdkPushAction:
   
   test_data = [
     ('preview', 'preview'),
+    ('experimental', 'experimental'),
     ('2021-04', '2021.04'),
     ('2021-07', '2021.07'),
     ('2021-10', '2021.10'),

--- a/scripts/update_specification_files.py
+++ b/scripts/update_specification_files.py
@@ -20,7 +20,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 ALL_API_SERVICES = ["marketingSolutions", "retailMedia", "commerceGrid"]
 NUM_YEARS_TO_KEEP = 1
-EVERGREEN_VERSIONS = {"preview",}
+PREVIEW_AND_EXPERIMENTAL_VERSIONS = {"preview", "experimental"}
 SPECIFICATION_EXTENSION = ".json"
 
 
@@ -48,7 +48,7 @@ def remove_out_of_support_specifications(specification_folder, reference_version
   folder_path = Path(specification_folder)
   for specification_path in folder_path.glob(f"*{SPECIFICATION_EXTENSION}"):
     _, version = _get_service_version_from_specification_filepath(specification_path)
-    if version.lower() in EVERGREEN_VERSIONS:
+    if version.lower() in PREVIEW_AND_EXPERIMENTAL_VERSIONS:
         continue
     if _is_more_recent_than_reference_version_minus(version, reference_version, num_years_to_keep):
         continue
@@ -110,7 +110,7 @@ def main():
         else:
             raise Exception(f'Unsupported command line option ({option}={value}).')
 
-    if release.lower() == "preview" or no_cleanup:
+    if release.lower() in PREVIEW_AND_EXPERIMENTAL_VERSIONS or no_cleanup:
       for api_service in ALL_API_SERVICES:
           LOGGER.info(f"Getting new specifications for {api_service}/{release}")
           download_specification(release, api_service, specification_folder, gateway_service)


### PR DESCRIPTION
Introduces experimental version support with the same treatment as preview. Renames
EVERGREEN_VERSIONS to PREVIEW_AND_EXPERIMENTAL_VERSIONS for clarity.

  JIRA: https://criteo.atlassian.net/browse/TECHNO-6425