### PR TITLE
🔧 Give Java experimental SDK a distinct artifactId

### DIFF
--- a/generator/java/build.gradle
+++ b/generator/java/build.gradle
@@ -45,6 +45,7 @@ task generateClient(type: GradleBuild) {
         def clientOutputDirPerVersion = clientOutputDir + "/" + parsedApiName;
         def specPath = it.path;
         def isPreviewOrExperimental = criteoApiVersion == 'preview' || criteoApiVersion == 'experimental';
+        def isExperimental = criteoApiVersion == 'experimental';
 
         def versionInNamespace =  criteoApiVersion
         if (versionInNamespace.matches("[0-9].*"))
@@ -54,6 +55,9 @@ task generateClient(type: GradleBuild) {
 
         def artifactVersion = isPreviewOrExperimental ? '0' : criteoApiVersion.replaceAll("_",".").toString()
         artifactVersion += ".${generatorVersion}.${getFormattedDate()}".toString() // example : 2021.01.0.211110 for stable , 0.0.211110 for preview
+
+        // experimental is a parallel track to preview, give it a distinct artifactId so its Maven coordinates don't collide with preview's on Central.
+        def artifactId = isExperimental ? "criteo-api-${criteoService}-sdk-experimental" : "criteo-api-${criteoService}-sdk"
 
         namespaceBase = "com." + namespaceBase; // 'com' is Java-specific => example: com.criteo.api.marketingsolutions.v2021_10
 
@@ -84,7 +88,7 @@ task generateClient(type: GradleBuild) {
                     apiPackage               : "${namespaceBase}.api".toString(), // com.criteo.api.marketingsolutions.v2021_10.api
                     modelPackage             : "${namespaceBase}.model".toString(),
                     artifactDescription      : "${language.toUpperCase()} SDK for Criteo API ${criteoService} for ${criteoApiVersion} version".toString(),
-                    artifactId               : "criteo-api-${criteoService}-sdk".toString(), // criteo-api-marketingsolutions-sdk
+                    artifactId               : artifactId.toString(), // criteo-api-marketingsolutions-sdk (or criteo-api-marketingsolutions-sdk-experimental)
                     artifactVersion          : "${artifactVersion}".toString(), // 2021.10.0.211110
                     artifactUrl              : "https://github.com/criteo/criteo-api-${language}-sdk".toString(),
                     dateLibrary              : technologyStack.toString(),


### PR DESCRIPTION
Preview and experimental both generated Maven coordinates com.criteo:criteo-api-{service}-sdk:0.0.YYMMDD, so publishing both on the same day made Sonatype reject the second release with a 400 at releaseSonatypeStagingRepository (duplicate GAV).

Suffix the artifactId with -experimental for the experimental track so the two lines can coexist on Central. Version scheme (0.0.YYMMDD) is unchanged.

This is what is causing this issue: https://github.com/criteo/criteo-api-java-sdk/actions/runs/28389831066/job/84113765699#step:3:801 on the Java `Automatic update of SDK` action.

JIRA: https://criteo.atlassian.net/browse/TECHNO-6425