### PR TITLE
Update name of action args

### DIFF
--- a/.github/workflows/update_oas.yml
+++ b/.github/workflows/update_oas.yml
@@ -5,7 +5,7 @@ on:
     inputs:
         latest-version:
           type: string
-          description: latest API version to onboard (ex 2026-07)
+          description: API version which is currently the Release Candidate (ex 2027-01)
         release-candidate:
           type: boolean
           description: skip cleanup of obsolete versions (use for release candidates)


### PR DESCRIPTION
Because "latest version to onboard" may be a bit ambiguous (is it the latest stable, or RC?)

This commit clarifies this